### PR TITLE
Changed *nix newline symbol "\n" for constant PHP_EOL

### DIFF
--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -53,7 +53,7 @@ class FFProbe extends Binary
 
         $ret = array();
 
-        foreach (explode("\n", $output) as $line) {
+        foreach (explode(PHP_EOL, $output) as $line) {
 
             if (in_array($line, array('[FORMAT]', '[/FORMAT]'))) {
                 continue;
@@ -97,7 +97,7 @@ class FFProbe extends Binary
             $this->binary, $pathfile, '-show_streams'
         ));
 
-        $output = explode("\n", $this->executeProbe($builder->getProcess()));
+        $output = explode(PHP_EOL, $this->executeProbe($builder->getProcess()));
 
         $ret = array();
         $n = 0;


### PR DESCRIPTION
Changed *nix newline symbol "\n" for PHP predefined constant PHP_EOL, because on Windows methods probeFormat and probeStreams returns wrong results.
