### PR TITLE
IMPORTANT If the conversion process (video) takes more time than the default value, the process is fails.

### DIFF
--- a/src/FFMpeg/FFMpeg.php
+++ b/src/FFMpeg/FFMpeg.php
@@ -265,6 +265,8 @@ class FFMpeg extends Binary
 
         $process = $builder->getProcess();
 
+        $process->setTimeout($this->timeout);
+
         $this->logger->addInfo(sprintf('FFmpeg executes command %s', $process->getCommandLine()));
 
         try {
@@ -397,6 +399,8 @@ class FFMpeg extends Binary
 
         foreach ($passes as $process) {
 
+            $process->setTimeout($this->timeout);
+
             $this->logger->addInfo(sprintf('FFmpeg executes command %s', $process->getCommandline()));
 
             try {
@@ -457,7 +461,7 @@ class FFMpeg extends Binary
         while (0 !== $value % $multiple) {
             $value++;
         }
-        
+
         return $value;
     }
 


### PR DESCRIPTION
IMPORTANT If the conversion process (video) takes more time than the default value, the process is fails.
