### PR TITLE
Fixed issue where process timeout is not set

### DIFF
--- a/src/FFMpeg/FFMpeg.php
+++ b/src/FFMpeg/FFMpeg.php
@@ -178,9 +178,8 @@ class FFMpeg extends Binary
         }
 
         $builder = ProcessBuilder::create($options);
+        $builder->setTimeout($this->timeout);
         $process = $builder->getProcess();
-        $process->setTimeout($this->timeout);
-
 
         $this->logger->addInfo(sprintf('FFmpeg executes command %s', $process->getCommandline()));
 
@@ -262,10 +261,9 @@ class FFMpeg extends Binary
         }
 
         $builder->add($outputPathfile);
+        $builder->setTimeout($this->timeout);
 
         $process = $builder->getProcess();
-
-        $process->setTimeout($this->timeout);
 
         $this->logger->addInfo(sprintf('FFmpeg executes command %s', $process->getCommandLine()));
 
@@ -389,17 +387,17 @@ class FFMpeg extends Binary
             ->add('-pass')->add('1')
             ->add('-passlogfile')->add($passPrefix)
             ->add('-an')->add($outputPathfile)
+            ->setTimeout($this->timeout)
             ->getProcess();
         $passes[] = $pass2
             ->add('-pass')->add('2')
             ->add('-passlogfile')->add($passPrefix)
             ->add('-ac')->add('2')
             ->add('-ar')->add('44100')->add($outputPathfile)
+            ->setTimeout($this->timeout)
             ->getProcess();
 
         foreach ($passes as $process) {
-
-            $process->setTimeout($this->timeout);
 
             $this->logger->addInfo(sprintf('FFmpeg executes command %s', $process->getCommandline()));
 


### PR DESCRIPTION
I discovered that the timeout setting was not being passed through to the symfony process component. The timeout setting needs to be passed either as an option at process create time or using the setTimeout() method of the builder. Because this did not work correctly, the default timeout of 60 seconds is applied.

There also seems to be an issue in that, at least for video encoding, a process timeout exception never appears. I tried to verify whether this is a PHP-FFmpeg problem or one in the symfony process component, but I haven't completed my inquiry into that question. Currently, there is nothing to help a user of FFmpeg understand when ffmpeg was killed due to the process being ended. FFMpeg seems to return a cryptic errorcode of '9' when this happens.
