### PR TITLE
Added Vorbis (.ogg) audio format

### DIFF
--- a/src/FFMpeg/Format/Audio/Vorbis.php
+++ b/src/FFMpeg/Format/Audio/Vorbis.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Format\Audio;
+
+/**
+ * The Vorbis audio format
+ */
+class Vorbis extends DefaultAudio
+{
+    public function __construct()
+    {
+        $this->audioCodec = 'vorbis';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtraParams()
+    {
+        return array('-strict', '-2');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAvailableAudioCodecs()
+    {
+        return array('vorbis');
+    }
+}

--- a/tests/FFMpeg/Tests/Format/Audio/VorbisTest.php
+++ b/tests/FFMpeg/Tests/Format/Audio/VorbisTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FFMpeg\Tests\Format\Audio;
+
+use FFMpeg\Format\Audio\Vorbis;
+
+class VorbisTest extends AudioTestCase
+{
+    public function getFormat()
+    {
+        return new Vorbis();
+    }
+}


### PR DESCRIPTION
I added the Vorbis audio format. I have success transcoding audio to Vorbis with this addition with FFMpeg compiled with libvorbis. Caveat: It can only transcode 2 channel (stereo) audio input.

I've tried to adhere PHP coding standards and run the files through php-cs-fixer.

Please let me know if I could do anything to improve this pull request. Thank you.
