### PR TITLE
Fixed sample for duration and added sample for codec_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,14 @@ $ffprobe
     ->streams('/path/to/video/mp4') // extracts streams informations
     ->videos()                      // filters video streams
     ->first()                       // returns the first video stream
-    ->get('duration');              // returns the duration property
+    ->get('codec_name');            // returns the codec_name property
+```
+
+```php
+$ffprobe = FFMpeg\FFProbe::create();
+$ffprobe
+    ->format('/path/to/video/mp4') // extracts file informations
+    ->get('duration');             // returns the duration property
 ```
 
 ##Using with Silex Microframework


### PR DESCRIPTION
I've updated the README file, because the existing example for getting the duration of a file was not working for file-types like WebM (see #103).

To not to loose the sample that was already in place, I changed it to return the codec-name for the video. Maybe returning width or height of a video is more used, but we can't have a sample for all ;)
