### PR TITLE
Fix video aspect ratio calculation

### DIFF
--- a/src/FFMpeg/FFProbe/DataMapping/Stream.php
+++ b/src/FFMpeg/FFProbe/DataMapping/Stream.php
@@ -72,7 +72,12 @@ class Stream extends AbstractData
 
         if (null !== $displayRatio && null !== $sampleRatio) {
             if ($sampleRatio[0] !== 1 && $sampleRatio[1] !== 1) {
-                $width = round($width / $sampleRatio[0] * $sampleRatio[1] * $displayRatio[0] / $displayRatio[1]);
+                if (null !== $width && null !== $height) {
+                    // stretch video according to pixel sample aspect ratio
+                    $width = round($width * ($sampleRatio[0] / $sampleRatio[1]));
+                    // set height according to display aspect ratio
+                    $height = round($width * ($displayRatio[1] / $displayRatio[0]));
+                }
             }
         }
 

--- a/tests/FFMpeg/Tests/FFProbe/DataMapping/StreamTest.php
+++ b/tests/FFMpeg/Tests/FFProbe/DataMapping/StreamTest.php
@@ -77,16 +77,19 @@ class StreamTest extends TestCase
         );
     }
 
-    public function testGetDimensionsFromVideoWithDisplayRatio()
+    /**
+     * @dataProvider providePropertiesForDimensionsExtraction
+     */
+    public function testGetDimensionsFromVideoWithDisplayRatio($data)
     {
-        $stream = new Stream(array('codec_type' => 'video', 'width' => 960, 'height' => 720, 'sample_aspect_ratio' => '4:3', 'display_aspect_ratio' => '16:9'));
-        $this->assertEquals(new Dimension(1280, 720), $stream->getDimensions());
-    }
-
-    public function testGetDimensionsFromVideoWith11SampleRatio()
-    {
-        $stream = new Stream(array('codec_type' => 'video', 'width' => 1920, 'height' => 1080, 'sample_aspect_ratio' => '1:1', 'display_aspect_ratio' => '16:9'));
-        $this->assertEquals(new Dimension(1920, 1080), $stream->getDimensions());
+        $stream = new Stream(array(
+            'codec_type' => 'video',
+            'width' => $data['width'],
+            'height' =>  $data['height'],
+            'sample_aspect_ratio' =>  $data['sar'],
+            'display_aspect_ratio' =>  $data['dar']
+        ));
+        $this->assertEquals(new Dimension($data['result_width'], $data['result_height']), $stream->getDimensions());
     }
 
     /**
@@ -101,5 +104,31 @@ class StreamTest extends TestCase
     public function provideInvalidRatios()
     {
         return array(array('0:1'), array('2:1:3'));
+    }
+
+    public function providePropertiesForDimensionsExtraction()
+    {
+        return array(
+            array(
+                array('width' => '960', 'height' => '720',
+                'sar' => '4:3', 'dar' => '16:9',
+                'result_width' => '1280', 'result_height' => '720'),
+            ),
+            array(
+                array('width' => '1920', 'height' => '1080',
+                'sar' => '1:1', 'dar' => '16:9',
+                'result_width' => '1920', 'result_height' => '1080'),
+            ),
+            array(
+                array('width' => '640', 'height' => '480',
+                'sar' => '75:74', 'dar' => '50:37',
+                'result_width' => '649', 'result_height' => '480'),
+            ),
+            array(
+                array('width' => '720', 'height' => '576',
+                  'sar' => '52:28', 'dar' => '16:9',
+                  'result_width' => '1337', 'result_height' => '752'),
+            ),
+        );
     }
 }


### PR DESCRIPTION
Hello, I ran into an issue where every video with a sample aspect ratio different from 1 were anamorphic.

This is because the calculation of the video resolution was errored in this case.
