### PR TITLE
More flexibility in encoding options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /vendor/
 /docs/build
 composer.phar
+composer.lock
 phpunit.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 /docs/build
 composer.phar
 composer.lock
-phpunit.xml
-
+phpunit*.xml

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 #PHP FFmpeg
 
-[![Build Status](https://secure.travis-ci.org/PHP-FFMpeg/PHP-FFMpeg.png?branch=master)](http://travis-ci.org/PHP-FFMpeg/PHP-FFMpeg)
-
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/607f3111-e2d7-44e8-8bcc-54dd64521983/big.png)](https://insight.sensiolabs.com/projects/607f3111-e2d7-44e8-8bcc-54dd64521983)
-
 An Object Oriented library to convert video/audio files with FFmpeg / AVConv.
 
 Check another amazing repo : [PHP FFMpeg extras](https://github.com/alchemy-fr/PHP-FFMpeg-Extras), you will find lots of Audio/Video formats there.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "curisdf/php-ffmpeg",
+    "name": "curtisdf/php-ffmpeg",
     "type": "library",
     "description": "FFMpeg PHP, an Object Oriented library to communicate with AVconv / ffmpeg",
     "keywords": ["video processing", "video", "audio processing", "audio", "avconv", "ffmpeg", "avprobe", "ffprobe"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "php-ffmpeg/php-ffmpeg",
+    "name": "curisdf/php-ffmpeg",
     "type": "library",
     "description": "FFMpeg PHP, an Object Oriented library to communicate with AVconv / ffmpeg",
     "keywords": ["video processing", "video", "audio processing", "audio", "avconv", "ffmpeg", "avprobe", "ffprobe"],


### PR DESCRIPTION
I split up the save() method in FFMpeg\Media\Video.php to allow bypassing the FFMpeg\Format\* classes and inputting an arbitrary array of encoding options. I did it in such a way that it doesn't break any existing functionality or the unit tests.  So now, in addition to using save() the same as before, the following can also be used instead:

$video->transcode($outputPathfile, $encodingOptions, $totalPasses, $progressableInterfaceOrCallback);

where $encodingOptions is a simple indexed array of FFMpeg options like what save() uses internally.

This allows for a much broader range of encoding situations, since the FFMpeg\Format\* classes enforce the "-b:v XXX" setting which is not always desirable (e.g. when doing Variable Bit Rate or Average Bit Rate encoding), and since the existing save() method hard-codes a long list of libx264 encoding options.  (I would have removed this list, but I wanted to keep my changes 100% backward-compatible in order to avoid breaking anyone's existing setup.)

I also added a couple filenames to the main .gitignore which probably should not be versioned.

Thanks!
-Curtis

