### PR TITLE
Use watermark image while watermarking!

### DIFF
--- a/src/FFMpeg/Filters/Video/WatermarkFilter.php
+++ b/src/FFMpeg/Filters/Video/WatermarkFilter.php
@@ -70,6 +70,6 @@ class WatermarkFilter implements VideoFilterInterface
                 break;
         }
 
-        return array('-vf', sprintf('overlay %s:%s', $x, $y));
+        return array('-vf', sprintf('movie=%s [watermark]; [in][watermark] overlay=%s:%s [out]', $this->watermarkPath, $x, $y));
     }
 }


### PR DESCRIPTION
The filter does not seem to actually use the watermark (image path). This update fixes the functionality.