### PR TITLE
Edit save - accepts additional FFMPEG commads

### DIFF
--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -58,7 +58,7 @@ class Video extends Audio
      *
      * @throws RuntimeException
      */
-    public function save(FormatInterface $format, $outputPathfile)
+    public function save(FormatInterface $format, $outputPathfile, $additionalCommands = [])
     {
         $commands = array('-y', '-i', $this->pathfile);
 
@@ -107,6 +107,8 @@ class Video extends Audio
             $commands[] = '-trellis';
             $commands[] = '1';
         }
+        
+        array_push($commands, $additionalCommands);
 
         if ($format instanceof AudioInterface) {
             if (null !== $format->getAudioKiloBitrate()) {


### PR DESCRIPTION
Save() now accepts an array of additional commands which defaults to [] if not given.  This is added onto $commands[].

inputing ['profile:v', 'baseline'] would save the video with constraint baseline instead of HIGH
