### PR TITLE
Allow usage of evenement v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php"                          : ">=5.3.3",
         "alchemy/binary-driver"        : "~1.5",
         "doctrine/cache"               : "~1.0",
-        "evenement/evenement"          : "~1.0",
+        "evenement/evenement"          : "^2.0|^1.0",
         "neutron/temporary-filesystem" : "~2.1, >=2.1.1"
     },
     "suggest": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | an enhancement
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes (travis fails because acces denied on http://video-js.zencoder.com/oceans-clip.mp4 probe)
| Fixed tickets | fixes #182 
| License | MIT

#### Description

The `evenement` lib v2.0 major BC break was the removement of `EventEmitter2` class, which is not used in the `PHP-FFMpeg`. Thus it is possible to require both versions, v1.0 and v2.0 via composer.

#### Purpose

Example: Users of lib A which requires `react/socket` which requires `evenement` in v2.0 but also require your `php-ffmpeg/php-ffmpeg` which requires `evenement` in v1.0 have a dependency conflict and have to manually add `"evenement/evenement": "2.0.0 as 1.0.0"` to their projects composer. Because of the v1.0 to v2.0 compatibility this works, so you can simply support both versions.