### PR TITLE
Add new filter implementing the -an ffmpeg functionality that strips …

### DIFF
--- a/src/FFMpeg/Filters/Video/RemoveAudioFilter.php
+++ b/src/FFMpeg/Filters/Video/RemoveAudioFilter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FFMpeg\Filters\Video;
+
+use FFMpeg\Format\VideoInterface;
+use FFMpeg\Media\Video;
+
+class RemoveAudioFilter implements VideoFilterInterface
+{
+
+    /** @var integer */
+    private $priority;
+
+    public function __construct($priority = 0)
+    {
+
+        $this->priority = $priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Video $video, VideoInterface $format)
+    {
+        $commands = array('-an');
+        return $commands;
+    }
+}

--- a/src/FFMpeg/Filters/Video/VideoFilters.php
+++ b/src/FFMpeg/Filters/Video/VideoFilters.php
@@ -132,4 +132,17 @@ class VideoFilters extends AudioFilters
 
         return $this;
     }
+
+
+    /**
+     * Removes the audio track from a video file
+     *
+     * @return $this
+     */
+    public function removeAudio()
+    {
+        $this->media->addFilter(new RemoveAudioFilter());
+
+        return $this;
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | Yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #issuenum |
| Related issues/PRs | #issuenum |
| License | MIT |
#### What's in this PR?

Add a new video filter, utilising the -an ffmpeg flag to strip audio from a video file.
#### Why?

Needed to be able to remove audio track from video file, couldn't a standard way find way of doing this in the current implementation.
#### Example Usage

``` php
$ffmpeg = FFMpeg\FFMpeg::create();
$video = $ffmpeg->open($input_filename);
$video->filters()->removeAudio();

//Save the file with format

```
#### To Do
- [ ] Create tests

…remove the audio from a video file
