### PR TITLE
Added support for ffmpeg's built-in aac audio encoder

### DIFF
--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -51,7 +51,7 @@ class X264 extends DefaultVideo
      */
     public function getAvailableAudioCodecs()
     {
-        return array('libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac');
+        return array('aac', 'libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | may |
| Deprecations? | no |
| Fixed tickets | - |
| Related issues/PRs | - |
| License | MIT |
#### What's in this PR?

As per [Encode/AAC](https://trac.ffmpeg.org/wiki/Encode/AAC), libvo_aacenc has been deprecated and the native encoder 'aac' has been added.
#### BC Breaks/Deprecations

With FFmpeg version 3 the 'libvo_aacenc' codec has been [removed](http://git.videolan.org/?p=ffmpeg.git;a=commit;h=e07e88cd82f78644ddcb10d7d3e0dd624fffe274) in [favour of the internal codec 'aac'.](http://git.videolan.org/?p=ffmpeg.git;a=commit;h=d9791a8656b5580756d5b7ecc315057e8cd4255e)
The 'aac' encoder requires '-strict -2' options in FFmpeg versions prior to 3.x as it was considered an unstable feature, therefore using X264->setAudioCoded('aac') with FFmpeg <3.x throws an error.
The ideal fix would be to have PHP-FFMpeg detect the underlaying FFmpeg version and enable/disable 'aac'/'libvo_aacenc' accordingly.
