### PR TITLE
Support for native aac encoder

### DIFF
--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -51,7 +51,7 @@ class X264 extends DefaultVideo
      */
     public function getAvailableAudioCodecs()
     {
-        return array('libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac');
+        return array('aac', 'libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac');
     }
 
     /**


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

FFMpeg has a native aac encoder.
Add Support for X264 format class.

#### Why?

The native FFmpeg AAC encoder. This is currently the second highest-quality AAC encoder available in FFmpeg and does not require an external library like the other AAC encoders described here. This is the default AAC encoder.
Source: https://trac.ffmpeg.org/wiki/Encode/AAC#NativeFFmpegAACencoder


native aac encoder not longer experimental since 5 December 2015.