### PR TITLE
Creation of a setPasses method for the X264 format.

### DIFF
--- a/docs/source/API/API/FFMpeg/Format/Video/X264.html
+++ b/docs/source/API/API/FFMpeg/Format/Video/X264.html
@@ -119,7 +119,17 @@
             </tr>
                     <tr>
                 <td class="type">
-                    string
+                    integer
+                </td>
+                <td class="last">
+                    <a href="#method_setPasses">setPasses</a>(integer $passes)
+                    <p>Sets the number of passes.</p>
+                </td>
+                <td></td>
+            </tr>
+                    <tr>
+                <td class="type">
+                    integer
                 </td>
                 <td class="last">
                     <a href="#method_getPasses">getPasses</a>()
@@ -502,9 +512,34 @@
                     </div>
     </div>
 
+                <h3 id="method_setPasses">
+        <div class="location">in <a href="../../../FFMpeg/Format/Video/X264.html#method_setPasses"><abbr title="FFMpeg\Format\Video\X264">X264</abbr></a> at line 68</div>
+        <code>            public            integer
+    <strong>setPasses</strong>(integer $passes)</code>
+    </h3>
+    <div class="details">
+        <p>Sets the number of passes.</p>
+        <p>
+</p>
+        <div class="tags">
+            
+                            <h4>Parameters</h4>
+
+                    <table>
+        <tr>
+            <td>integer</td>
+            <td>$passes</td>
+        </tr>
+    </table>
+
+            
+            
+                    </div>
+    </div>
+
                 <h3 id="method_getPasses">
-        <div class="location">at line 68</div>
-        <code>            public            string
+        <div class="location">in <a href="../../../FFMpeg/Format/Video/X264.html#method_getPasses"><abbr title="FFMpeg\Format\Video\X264">X264</abbr></a> at line 79</div>
+        <code>            public            integer
     <strong>getPasses</strong>()</code>
     </h3>
     <div class="details">
@@ -517,7 +552,7 @@
 
                     <table>
         <tr>
-            <td>string</td>
+            <td>integer</td>
             <td>
 </td>
         </tr>

--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -19,6 +19,9 @@ class X264 extends DefaultVideo
     /** @var boolean */
     private $bframesSupport = true;
 
+    /** @var integer */
+    private $passes = 2;
+
     public function __construct($audioCodec = 'libfaac', $videoCodec = 'libx264')
     {
         $this
@@ -63,11 +66,22 @@ class X264 extends DefaultVideo
     }
 
     /**
+     * @param $passes
+     *
+     * @return X264
+     */
+    public function setPasses($passes)
+    {
+        $this->passes = $passes;
+        return $this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getPasses()
     {
-        return 2;
+        return $this->passes;
     }
 
     /**


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | -
| Related issues/PRs | #250 
| License            | MIT

#### What's in this PR?

This PR adds a method to the Format/Video/X264 class to be able to set the number of passes for this format.

#### Why?

The number of passes may be a potential source of trouble for large files.

