### PR TITLE
Creation of a Pad filter which allows the user to resize his video, using black bars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 composer.phar
 composer.lock
 phpunit.xml
+sami.phar

--- a/README.md
+++ b/README.md
@@ -221,11 +221,27 @@ Resizes a video to a given size.
 $video->filters()->resize($dimension, $mode, $useStandards);
 ```
 
-The resize filter takes three parameters :
+The resize filter takes three parameters:
 
 - `$dimension`, an instance of `FFMpeg\Coordinate\Dimension`
 - `$mode`, one of the constants `FFMpeg\Filters\Video\ResizeFilter::RESIZEMODE_*` constants
 - `$useStandards`, a boolean to force the use of the nearest aspect ratio standard.
+
+If you want a video in a non-standard ratio, you can use the padding filter to resize your video in the desired size, and wrap it into black bars.
+
+```php
+$video->filters()->pad($dimension);
+```
+
+The pad filter takes one parameter:
+
+- `$dimension`, an instance of `FFMpeg\Coordinate\Dimension`
+
+Don't forget to save it afterwards.
+
+```php
+$video->save(new FFMpeg\Format\Video\X264(), $new_file);
+```
 
 ###### Watermark
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
             "name": "Patrik Karisch",
             "email": "patrik@karisch.guru",
             "homepage": "http://www.karisch.guru"
+        },
+        {
+            "name": "Romain Biard",
+            "email": "romain.biard@gmail.com",
+            "homepage": "https://www.strime.io/"
         }
     ],
     "require": {

--- a/src/FFMpeg/Filters/Video/PadFilter.php
+++ b/src/FFMpeg/Filters/Video/PadFilter.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Strime <contact@strime.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Filters\Video;
+
+use FFMpeg\Coordinate\Dimension;
+use FFMpeg\Exception\RuntimeException;
+use FFMpeg\Media\Video;
+use FFMpeg\Format\VideoInterface;
+
+class PadFilter implements VideoFilterInterface
+{
+    /** @var Dimension */
+    private $dimension;
+    /** @var integer */
+    private $priority;
+
+    public function __construct(Dimension $dimension, $priority = 0)
+    {
+        $this->dimension = $dimension;
+        $this->priority = $priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * @return Dimension
+     */
+    public function getDimension()
+    {
+        return $this->dimension;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Video $video, VideoInterface $format)
+    {
+        $commands = array();
+
+        $commands[] = '-vf';
+        $commands[] = 'pad=' . $this->dimension->getWidth() . ':' . $this->dimension->getHeight() . ':(' . $this->dimension->getWidth() . '-iw)/2:(' . $this->dimension->getHeight() .'-ih)/2';
+
+        return $commands;
+    }
+}

--- a/src/FFMpeg/Filters/Video/PadFilter.php
+++ b/src/FFMpeg/Filters/Video/PadFilter.php
@@ -53,7 +53,7 @@ class PadFilter implements VideoFilterInterface
         $commands = array();
 
         $commands[] = '-vf';
-        $commands[] = 'pad=' . $this->dimension->getWidth() . ':' . $this->dimension->getHeight() . ':(' . $this->dimension->getWidth() . '-iw)/2:(' . $this->dimension->getHeight() .'-ih)/2';
+        $commands[] = 'scale=iw*min(' . $this->dimension->getWidth() . '/iw\,' . $this->dimension->getHeight() .'/ih):ih*min(' . $this->dimension->getWidth() . '/iw\,' . $this->dimension->getHeight() .'/ih),pad=' . $this->dimension->getWidth() . ':' . $this->dimension->getHeight() . ':(' . $this->dimension->getWidth() . '-iw)/2:(' . $this->dimension->getHeight() .'-ih)/2';
 
         return $commands;
     }

--- a/src/FFMpeg/Filters/Video/VideoFilters.php
+++ b/src/FFMpeg/Filters/Video/VideoFilters.php
@@ -98,6 +98,20 @@ class VideoFilters extends AudioFilters
         return $this;
     }
 
+    /**
+     * Adds padding (black bars) to a video.
+     *
+     * @param Dimension $dimension
+     *
+     * @return VideoFilters
+     */
+    public function pad(Dimension $dimension)
+    {
+        $this->media->addFilter(new PadFilter($dimension));
+
+        return $this;
+    }
+
     public function rotate($angle)
     {
         $this->media->addFilter(new RotateFilter($angle, 30));

--- a/tests/Unit/Filters/Video/PadFilterTest.php
+++ b/tests/Unit/Filters/Video/PadFilterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Filters\Video;
+
+use FFMpeg\Filters\Video\PadFilter;
+use Tests\FFMpeg\Unit\TestCase;
+use FFMpeg\FFProbe\DataMapping\Stream;
+use FFMpeg\FFProbe\DataMapping\StreamCollection;
+use FFMpeg\Coordinate\Dimension;
+
+class PadFilterTest extends TestCase
+{
+    /**
+     * @dataProvider provideDimensions
+     */
+    public function testApply(Dimension $dimension, $width, $height, $expected)
+    {
+        $video = $this->getVideoMock();
+        $pathfile = '/path/to/file'.mt_rand();
+
+        $format = $this->createMock('FFMpeg\Format\VideoInterface');
+
+        $streams = new StreamCollection(array(
+            new Stream(array(
+                'codec_type' => 'video',
+                'width'      => $width,
+                'height'     => $height,
+            ))
+        ));
+
+        $filter = new PadFilter($dimension);
+        $this->assertEquals($expected, $filter->apply($video, $format));
+    }
+
+    public function provideDimensions()
+    {
+        return array(
+            array(new Dimension(1000, 800), 640, 480, array('-vf', 'scale=iw*min(1000/iw\,800/ih):ih*min(1000/iw\,800/ih),pad=1000:800:(1000-iw)/2:(800-ih)/2')),
+            array(new Dimension(300, 600), 640, 480, array('-vf', 'scale=iw*min(300/iw\,600/ih):ih*min(300/iw\,600/ih),pad=300:600:(300-iw)/2:(600-ih)/2')),
+            array(new Dimension(100, 900), 640, 480, array('-vf', 'scale=iw*min(100/iw\,900/ih):ih*min(100/iw\,900/ih),pad=100:900:(100-iw)/2:(900-ih)/2')),
+            array(new Dimension(1200, 200), 640, 480, array('-vf', 'scale=iw*min(1200/iw\,200/ih):ih*min(1200/iw\,200/ih),pad=1200:200:(1200-iw)/2:(200-ih)/2')),
+        );
+    }
+}

--- a/tests/Unit/Filters/Video/PadFilterTest.php
+++ b/tests/Unit/Filters/Video/PadFilterTest.php
@@ -18,7 +18,7 @@ class PadFilterTest extends TestCase
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
 
-        $format = $this->createMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMock('FFMpeg\Format\VideoInterface');
 
         $streams = new StreamCollection(array(
             new Stream(array(


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #227 
| Related issues/PRs | #227 
| License            | MIT

#### What's in this PR?

This PR contains a new filter which allows the user to resize a video with padding.

This is complementary to the resize filter. You don't have to choose a mode of resize, your video will be resized to fit in the new dimensions, and will be wraps into black bars if the ratio of the new video is not the same of the old one.

#### Why?

This is complementary to the resize filter.

I've created a new filter instead of updating the resize one because the FFMPEG command was way too different for this feature.

#### Example Usage

It works in the same way than the resize filter.

```php
$video->filters()->pad($dimension);
```

The pad filter takes one parameter:

- `$dimension`, an instance of `FFMpeg\Coordinate\Dimension`

Don't forget to save it afterwards.

```php
$video->save(new FFMpeg\Format\Video\X264(), $new_file);
```



