### PR TITLE
Change installation method to composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,8 @@ appear in latest ffmpeg version.
 
 The recommended way to install PHP-FFMpeg is through [Composer](https://getcomposer.org).
 
-```json
-{
-    "require": {
-        "php-ffmpeg/php-ffmpeg": "~0.5"
-    }
-}
+```bash
+$ composer require php-ffmpeg/php-ffmpeg
 ```
 
 ## Basic Usage


### PR DESCRIPTION
The composer.json SHOULD NOT be edited by hand for installation.

| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | -
| Related issues/PRs | -
| License            | MIT

#### What's in this PR?

Just small change in README.md to use `composer require` for installation.

#### Why?

Because editing the composer.json manually is considered a bad practise.

