### PR TITLE
Add audio metadata filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ method. It only accepts audio filters.
 You can build your own filters and some are bundled in PHP-FFMpeg - they are
 accessible through the `FFMpeg\Media\Audio::filters` method.
 
-#### Metadata
+###### Metadata
 
 Add metadata to audio files. Just pass an array of key=value pairs of all
 metadata you would like to add. If no arguments are passed into the filter

--- a/README.md
+++ b/README.md
@@ -328,6 +328,27 @@ method. It only accepts audio filters.
 You can build your own filters and some are bundled in PHP-FFMpeg - they are
 accessible through the `FFMpeg\Media\Audio::filters` method.
 
+#### Metadata
+
+Add metadata to audio files. Just pass an array of key=value pairs of all
+metadata you would like to add. If no arguments are passed into the filter
+all metadata will be removed from input file. Currently supported data is
+title, artist, album, artist, composer, track, year, description, artwork
+
+```php
+$audio->filters()->addMetadata(["title" => "Some Title", "track" => 1]);
+
+//remove all metadata and video streams from audio file
+$audio->filters()->addMetadata();
+```
+
+Add artwork to the audio file
+```php
+$audio->filters()->addMetadata(["artwork" => "/path/to/image/file.jpg"]);
+```
+NOTE: at present ffmpeg (version 3.2.2) only supports artwork output for .mp3
+files
+
 ###### Resample
 
 Resamples an audio file.

--- a/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
+++ b/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
@@ -9,16 +9,19 @@ class AddMetadataFilter implements AudioFilterInterface
 {	
 	/** @var Array */
 	private $metaArr;
+	/** @var Integer */
+	private $priority;
 
-	function __construct($data = null)
+	function __construct($data = null, $priority = 9)
 	{
 		$this->metaArr = $data;
+		$this->priority = $priority;
 	}
 
 	public function getPriority()
 	{
 		//must be of high priority in case theres a second input stream (artwork) to register with audio
-		return 9;
+		return $this->priority;
 	}
 
 	public function apply(Audio $audio, AudioInterface $format)

--- a/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
+++ b/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
@@ -1,0 +1,42 @@
+<?php
+namespace FFMpeg\Filters\Audio;
+
+use FFMpeg\Filters\Audio\AudioFilterInterface;
+use FFMpeg\Format\AudioInterface;
+use FFMpeg\Media\Audio;
+
+class AddMetadataFilter implements AudioFilterInterface
+{	
+	/** @var Array */
+	private $metaArr;
+
+	function __construct($data = null)
+	{
+		$this->metaArr = $data;
+	}
+
+	public function getPriority()
+	{
+		//must be of high priority in case theres a second input stream (artwork) to register with audio
+		return 9;
+	}
+
+	public function apply(Audio $audio, AudioInterface $format)
+	{
+		if (is_null($this->metaArr))
+			return ['-map_metadata', '-1', '-vn'];
+
+		$metadata = [];
+
+		if (array_key_exists("artwork", $this->metaArr)) {
+			array_push($metadata, "-i", $this->metaArr['artwork'], "-map", "0", "-map", "1");
+			unset($this->metaArr['artwork']);
+		}
+
+		foreach ($this->metaArr as $k => $v) {
+			array_push($metadata, "-metadata", "$k=$v");
+		}
+
+		return $metadata;
+	}
+}

--- a/src/FFMpeg/Filters/Audio/AudioFilters.php
+++ b/src/FFMpeg/Filters/Audio/AudioFilters.php
@@ -2,6 +2,7 @@
 
 namespace FFMpeg\Filters\Audio;
 
+use FFMpeg\Filters\Audio\AddMetadataFilter;
 use FFMpeg\Media\Audio;
 
 class AudioFilters
@@ -23,6 +24,27 @@ class AudioFilters
     public function resample($rate)
     {
         $this->media->addFilter(new AudioResamplableFilter($rate));
+
+        return $this;
+    }
+
+    /**
+     * Add metadata to an audio file. If no arguments are given then filter
+     * will remove all metadata from the audio file
+     * @param Array|Null $data  If array must contain one of these key/value pairs:
+     *    - "title": Title metadata
+     *    - "artist": Artist metadata
+     *    - "composer": Composer metadata
+     *    - "album": Album metadata
+     *    - "track": Track metadata
+     *    - "artwork": Song artwork. String of file path
+     *    - "year": Year metadata
+     *    - "genre": Genre metadata
+     *    - "description": Description metadata
+     */
+    public function addMetadata($data = null)
+    {
+        $this->media->addFilter(new AddMetadataFilter($data));
 
         return $this;
     }

--- a/tests/Unit/Filters/Audio/AudioMetadataTest.php
+++ b/tests/Unit/Filters/Audio/AudioMetadataTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Filters\Audio;
+
+use FFMpeg\Filters\Audio\AudioFilters;
+use Tests\FFMpeg\Unit\TestCase;
+
+class AudioMetadataTest extends TestCase
+{
+    public function testAddMetadata()
+    {
+        $capturedFilter = null;
+
+        $audio = $this->getAudioMock();
+        $audio->expects($this->once())
+            ->method('addFilter')
+            ->with($this->isInstanceOf('FFMpeg\Filters\Audio\AddMetadataFilter'))
+            ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
+                $capturedFilter = $filter;
+            }));
+        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+
+        $filters = new AudioFilters($audio);
+        $filters->addMetadata(array('title' => "Hello World"));
+        $this->assertEquals(array(0 => "-metadata", 1 => "title=Hello World"), $capturedFilter->apply($audio, $format));
+    }
+
+    public function testRemoveMetadata()
+    {
+        $capturedFilter = null;
+
+        $audio = $this->getAudioMock();
+        $audio->expects($this->once())
+            ->method('addFilter')
+            ->with($this->isInstanceOf('FFMpeg\Filters\Audio\AddMetadataFilter'))
+            ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
+                $capturedFilter = $filter;
+            }));
+        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+
+        $filters = new AudioFilters($audio);
+        $filters->addMetadata();
+        $this->assertEquals(array(0 => "-map_metadata", 1 => "-1", 2 => "-vn"), $capturedFilter->apply($audio, $format));
+    }
+}

--- a/tests/Unit/Filters/Audio/AudioMetadataTest.php
+++ b/tests/Unit/Filters/Audio/AudioMetadataTest.php
@@ -25,6 +25,24 @@ class AudioMetadataTest extends TestCase
         $this->assertEquals(array(0 => "-metadata", 1 => "title=Hello World"), $capturedFilter->apply($audio, $format));
     }
 
+    public function testAddArtwork()
+    {
+        $capturedFilter = null;
+
+        $audio = $this->getAudioMock();
+        $audio->expects($this->once())
+            ->method('addFilter')
+            ->with($this->isInstanceOf('FFMpeg\Filters\Audio\AddMetadataFilter'))
+            ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
+                $capturedFilter = $filter;
+            }));
+        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+
+        $filters = new AudioFilters($audio);
+        $filters->addMetadata(array('genre' => 'Some Genre', 'artwork' => "/path/to/file.jpg"));
+        $this->assertEquals(array(0 => "-i", 1 => "/path/to/file.jpg", 2 => "-map", 3 => "0", 4 => "-map", 5 => "1", 6 => "-metadata", 7 => "genre=Some Genre"), $capturedFilter->apply($audio, $format));
+    }
+
     public function testRemoveMetadata()
     {
         $capturedFilter = null;


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #175 #120 
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Adds a new Audio Filter. Using ffmpeg -metadata utility we can set metadata values such as title, artist, album etc...
Filter also can add image files to audio files (album artwork)
By not supplying an argument to the filter, it will remove all metadata, including previously set artworks

#### Why?

A simple way to add metadata or album artwork to audio files

#### Example Usage

```php
$ffmpeg = new FFMpeg\FFMpeg::create();
$audio = $ffmpeg->open($file_path);
$audio->addMetadata([
    "title" => "Some Title",
    "album" => "Some Album",
    "artwork" => "/path/to/some/file.jpg"
]);
