### PR TITLE
Added a getAsBase64() method to Frame object

### DIFF
--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -118,12 +118,16 @@ class Frame extends AbstractMediaType
         $commands = array_merge($commands, array($pathfile));
 
         try {
-            $this->driver->command($commands);
+            if(!$returnBase64) {
+                $this->driver->command($commands);
+                return $this
+            }
+            else {
+                return $this->driver->command($commands);
+            }
         } catch (ExecutionFailureException $e) {
             $this->cleanupTemporaryFile($pathfile);
             throw new RuntimeException('Unable to save frame', $e->getCode(), $e);
         }
-
-        return $this;
     }
 }

--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -120,7 +120,7 @@ class Frame extends AbstractMediaType
         try {
             if(!$returnBase64) {
                 $this->driver->command($commands);
-                return $this
+                return $this;
             }
             else {
                 return $this->driver->command($commands);

--- a/tests/Unit/Media/FrameTest.php
+++ b/tests/Unit/Media/FrameTest.php
@@ -70,7 +70,27 @@ class FrameTest extends AbstractMediaTestCase
         $frame = new Frame($this->getVideoMock(__FILE__), $driver, $ffprobe, $timecode);
         $this->assertSame($frame, $frame->save($pathfile, $accurate));
     }
-
+    
+    /**
+     * @dataProvider provideGetAsBase64Options
+     */
+    public function testGetAsBase64($accurate, $commands)
+    {
+        $driver = $this->getFFMpegDriverMock();
+        $ffprobe = $this->getFFProbeMock();
+        $timecode = $this->getTimeCodeMock();
+        $timecode->expects($this->once())
+        ->method('__toString')
+        ->will($this->returnValue('timecode'));
+        
+        $driver->expects($this->once())
+        ->method('command')
+        ->with($commands);
+        
+        $frame = new Frame($this->getVideoMock(__FILE__), $driver, $ffprobe, $timecode);
+        $frame->getAsBase64($accurate);
+    }
+    
     public function provideSaveOptions()
     {
         return array(
@@ -85,6 +105,23 @@ class FrameTest extends AbstractMediaTestCase
                 '-vframes', '1', '-ss', 'timecode',
                 '-f', 'image2'
             )),
+        );
+    }
+    
+    public function provideGetAsBase64Options()
+    {
+        return array(
+                array(false, array(
+                        '-y', '-ss', 'timecode',
+                        '-i', __FILE__,
+                        '-vframes', '1',
+                        '-f', 'image2pipe', '-')
+                ),
+                array(true, array(
+                        '-y', '-i', __FILE__,
+                        '-vframes', '1', '-ss', 'timecode',
+                        '-f', 'image2pipe', '-'
+                )),
         );
     }
 }

--- a/tests/Unit/Media/FrameTest.php
+++ b/tests/Unit/Media/FrameTest.php
@@ -50,7 +50,7 @@ class FrameTest extends AbstractMediaTestCase
     /**
      * @dataProvider provideSaveOptions
      */
-    public function testSave($accurate, $commands)
+    public function testSave($accurate, $base64, $commands)
     {
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
@@ -67,61 +67,41 @@ class FrameTest extends AbstractMediaTestCase
             ->method('command')
             ->with($commands);
 
-        $frame = new Frame($this->getVideoMock(__FILE__), $driver, $ffprobe, $timecode);
-        $this->assertSame($frame, $frame->save($pathfile, $accurate));
-    }
-    
-    /**
-     * @dataProvider provideGetAsBase64Options
-     */
-    public function testGetAsBase64($accurate, $commands)
-    {
-        $driver = $this->getFFMpegDriverMock();
-        $ffprobe = $this->getFFProbeMock();
-        $timecode = $this->getTimeCodeMock();
-        $timecode->expects($this->once())
-        ->method('__toString')
-        ->will($this->returnValue('timecode'));
-        
-        $driver->expects($this->once())
-        ->method('command')
-        ->with($commands);
-        
-        $frame = new Frame($this->getVideoMock(__FILE__), $driver, $ffprobe, $timecode);
-        $frame->getAsBase64($accurate);
+        if(!$base64) {
+            $frame = new Frame($this->getVideoMock(__FILE__), $driver, $ffprobe, $timecode);
+            $this->assertSame($frame, $frame->save($pathfile, $accurate, $base64));
+        }
+        else {
+            $frame = new Frame($this->getVideoMock(__FILE__), $driver, $ffprobe, $timecode);
+            $frame->save($pathfile, $accurate, $base64);
+        }
     }
     
     public function provideSaveOptions()
     {
         return array(
-            array(false, array(
+            array(false, false, array(
                 '-y', '-ss', 'timecode',
                 '-i', __FILE__,
                 '-vframes', '1',
                 '-f', 'image2')
             ),
-            array(true, array(
+            array(true, false, array(
                 '-y', '-i', __FILE__,
                 '-vframes', '1', '-ss', 'timecode',
-                '-f', 'image2'
-            )),
-        );
-    }
-    
-    public function provideGetAsBase64Options()
-    {
-        return array(
-                array(false, array(
-                        '-y', '-ss', 'timecode',
-                        '-i', __FILE__,
-                        '-vframes', '1',
-                        '-f', 'image2pipe', '-')
-                ),
-                array(true, array(
-                        '-y', '-i', __FILE__,
-                        '-vframes', '1', '-ss', 'timecode',
-                        '-f', 'image2pipe', '-'
-                )),
+                '-f', 'image2')
+            ),
+            array(false, true, array(
+                    '-y', '-ss', 'timecode',
+                    '-i', __FILE__,
+                    '-vframes', '1',
+                    '-f', 'image2pipe', '-')
+            ),
+            array(true, true, array(
+                    '-y', '-i', __FILE__,
+                    '-vframes', '1', '-ss', 'timecode',
+                    '-f', 'image2pipe', '-')
+            )
         );
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | 
| Related issues/PRs | 
| License            | MIT

#### What's in this PR?

For now, when we are generating thumbnails, we are forced to save the thumbnail on the disk. This can be very time consuming in some cases.

My method allow us to retrieve directly base 64 encoded image as a string, so you can embed it into an html <img /> tag or whatever

#### Why?

I had the issue, I am generating a thumbnail to display on a page and I didn't want to save it in a temporary file that would be deleted each time user navigate on a new video

#### Example Usage

```
echo "<img src='data:images/png;base64," . getThumbnail("/home/guillaume/Vidéos/Seigneur des anneaux/01_La Communauté De L'anneau Partie 1.avi") . "' />";

function getThumbnail($videoPath) {
	setlocale(LC_CTYPE, "en_US.UTF-8"); # Else, the process will strip non ascii chars (like é, è, à, etc...)
	$ffmpeg = FFMpeg\FFMpeg::create();
	$movie = $ffmpeg->open($videoPath);

	$frame = $movie->frame(FFMpeg\Coordinate\TimeCode::fromSeconds(60))->getAsBase64();

	return $frame;
}
```

#### Note

- Currently, there is just one test case and it doesn't test a real case with a real frame but it test that the driver send the correct commands to ffmpeg
