### PR TITLE
Audio Clip

### DIFF
--- a/src/FFMpeg/Coordinate/TimeCode.php
+++ b/src/FFMpeg/Coordinate/TimeCode.php
@@ -89,4 +89,32 @@ class TimeCode
 
         return new static($hours, $minutes, $seconds, $frames);
     }
+
+    /**
+     * Returns this timecode in seconds
+     * @return int
+     */
+    public function toSeconds() {
+        $seconds = 0;
+
+        $seconds += $this->hours * 60 * 60;
+        $seconds += $this->minutes * 60;
+        $seconds += $this->seconds;
+
+        // TODO: Handle frames?
+
+        return (int) $seconds;
+    }
+
+    /**
+     * Helper function wether `$timecode` is after this one
+     *
+     * @param   TimeCode    $timecode   The Timecode to compare
+     * @return bool
+     */
+    public function isAfter(TimeCode $timecode) {
+        // convert everything to seconds and compare
+        return ($this->toSeconds() > $timecode->toSeconds());
+    }
+
 }

--- a/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
+++ b/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
@@ -1,4 +1,14 @@
 <?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
 namespace FFMpeg\Filters\Audio;
 
 use FFMpeg\Filters\Audio\AudioFilterInterface;

--- a/src/FFMpeg/Filters/Audio/AudioClipFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioClipFilter.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Filters\Audio;
+
+use FFMpeg\Coordinate\TimeCode;
+use FFMpeg\Format\AudioInterface;
+use FFMpeg\Media\Audio;
+
+class AudioClipFilter implements AudioFilterInterface {
+
+    /**
+     * @var TimeCode
+     */
+    private $start;
+
+    /**
+     * @var TimeCode
+     */
+    private $duration;
+
+    /**
+     * @var int
+     */
+    private $priority;
+
+
+    public function __construct(TimeCode $start, TimeCode $duration = null, int $priority = 0) {
+        $this->start = $start;
+        $this->duration = $duration;
+        $this->priority = $priority;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPriority() {
+        return $this->priority;
+    }
+
+     /**
+      * Returns the start position the audio is being cutted
+      *
+      * @return TimeCode
+      */
+     public function getStart() {
+         return $this->start;
+     }
+
+     /**
+      * Returns how long the audio is being cutted. Returns null when the duration is infinite,
+      *
+      * @return TimeCode|null
+      */
+     public function getDuration() {
+         return $this->duration;
+     }
+
+     /**
+      * @inheritDoc
+      */
+     public function apply(Audio $audio, AudioInterface $format) {
+         $commands = array('-ss', (string) $this->start);
+
+         if ($this->duration !== null) {
+            $commands[] = '-t';
+            $commands[] = (string) $this->duration;
+         }
+
+         return $commands;
+     }
+
+}

--- a/src/FFMpeg/Filters/Audio/AudioClipFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioClipFilter.php
@@ -33,7 +33,7 @@ class AudioClipFilter implements AudioFilterInterface {
     private $priority;
 
 
-    public function __construct(TimeCode $start, TimeCode $duration = null, int $priority = 0) {
+    public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0) {
         $this->start = $start;
         $this->duration = $duration;
         $this->priority = $priority;

--- a/src/FFMpeg/Filters/Audio/AudioClipFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioClipFilter.php
@@ -75,6 +75,9 @@ class AudioClipFilter implements AudioFilterInterface {
             $commands[] = (string) $this->duration;
          }
 
+         $commands[] = '-acodec';
+         $commands[] = 'copy';
+
          return $commands;
      }
 

--- a/src/FFMpeg/Filters/Audio/AudioFilters.php
+++ b/src/FFMpeg/Filters/Audio/AudioFilters.php
@@ -13,6 +13,7 @@ namespace FFMpeg\Filters\Audio;
 
 use FFMpeg\Filters\Audio\AddMetadataFilter;
 use FFMpeg\Media\Audio;
+use FFMpeg\Coordinate\TimeCode;
 
 class AudioFilters
 {
@@ -54,6 +55,19 @@ class AudioFilters
     public function addMetadata($data = null)
     {
         $this->media->addFilter(new AddMetadataFilter($data));
+
+        return $this;
+    }
+
+    /**
+     * Cuts the audio at `$start`, optionally define the end
+     *
+     * @param   TimeCode    $start      Where the clipping starts(seek to time)
+     * @param   TimeCode    $duration   How long the clipped audio should be
+     * @return AudioFilters
+     */
+    public function clip($start, $duration = null) {
+        $this->media->addFilter(new AudioClipFilter($start, $duration));
 
         return $this;
     }

--- a/src/FFMpeg/Filters/Audio/AudioFilters.php
+++ b/src/FFMpeg/Filters/Audio/AudioFilters.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FFMpeg\Filters\Audio;
 
 use FFMpeg\Filters\Audio\AddMetadataFilter;

--- a/src/FFMpeg/Filters/Audio/SimpleFilter.php
+++ b/src/FFMpeg/Filters/Audio/SimpleFilter.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FFMpeg\Filters\Audio;
 
 use FFMpeg\Media\Audio;

--- a/tests/Unit/Filters/Audio/AudioClipTest.php
+++ b/tests/Unit/Filters/Audio/AudioClipTest.php
@@ -9,6 +9,8 @@ use Tests\FFMpeg\Unit\TestCase;
 class AudioClipTest extends TestCase {
 
     public function testClipping() {
+        $capturedFilter = null;
+
         $audio = $this->getAudioMock();
         $audio->expects($this->once())
             ->method('addFilter')
@@ -25,6 +27,8 @@ class AudioClipTest extends TestCase {
     }
 
     public function testClippingWithDuration() {
+        $capturedFilter = null;
+        
         $audio = $this->getAudioMock();
         $audio->expects($this->once())
             ->method('addFilter')

--- a/tests/Unit/Filters/Audio/AudioClipTest.php
+++ b/tests/Unit/Filters/Audio/AudioClipTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Filters\Audio;
+
+use FFMpeg\Filters\Audio\AudioFilters;
+use FFMpeg\Coordinate\TimeCode;
+use Tests\FFMpeg\Unit\TestCase;
+
+class AudioClipTest extends TestCase {
+
+    public function testClipping() {
+        $audio = $this->getAudioMock();
+        $audio->expects($this->once())
+            ->method('addFilter')
+            ->with($this->isInstanceOf('FFMpeg\Filters\Audio\AudioClipFilter'))
+            ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
+                $capturedFilter = $filter;
+        }));
+        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+
+        $filters = new AudioFilters($audio);
+
+        $filters->clip(TimeCode::fromSeconds(5));
+        $this->assertEquals(array(0 => '-ss', 1 => '00:00:05.00'), $capturedFilter->apply($audio, $format));
+    }
+
+    public function testClippingWithDuration() {
+        $audio = $this->getAudioMock();
+        $audio->expects($this->once())
+            ->method('addFilter')
+            ->with($this->isInstanceOf('FFMpeg\Filters\Audio\AudioClipFilter'))
+            ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
+                $capturedFilter = $filter;
+        }));
+        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+
+        $filters = new AudioFilters($audio);
+
+        $filters->clip(TimeCode::fromSeconds(5), TimeCode::fromSeconds(5));
+        $this->assertEquals(array(0 => '-ss', 1 => '00:00:05.00', 2 => '-t', 3 => '00:00:05.00'), $capturedFilter->apply($audio, $format));
+    }
+
+}

--- a/tests/Unit/Filters/Audio/AudioClipTest.php
+++ b/tests/Unit/Filters/Audio/AudioClipTest.php
@@ -23,12 +23,12 @@ class AudioClipTest extends TestCase {
         $filters = new AudioFilters($audio);
 
         $filters->clip(TimeCode::fromSeconds(5));
-        $this->assertEquals(array(0 => '-ss', 1 => '00:00:05.00'), $capturedFilter->apply($audio, $format));
+        $this->assertEquals(array(0 => '-ss', 1 => '00:00:05.00', 2 => '-acodec', 3 => 'copy'), $capturedFilter->apply($audio, $format));
     }
 
     public function testClippingWithDuration() {
         $capturedFilter = null;
-        
+
         $audio = $this->getAudioMock();
         $audio->expects($this->once())
             ->method('addFilter')
@@ -41,7 +41,7 @@ class AudioClipTest extends TestCase {
         $filters = new AudioFilters($audio);
 
         $filters->clip(TimeCode::fromSeconds(5), TimeCode::fromSeconds(5));
-        $this->assertEquals(array(0 => '-ss', 1 => '00:00:05.00', 2 => '-t', 3 => '00:00:05.00'), $capturedFilter->apply($audio, $format));
+        $this->assertEquals(array(0 => '-ss', 1 => '00:00:05.00', 2 => '-t', 3 => '00:00:05.00', 4 => '-acodec', 5 => 'copy'), $capturedFilter->apply($audio, $format));
     }
 
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       |Yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | 
| Related issues/PRs | #240 
| License            | MIT

#### What's in this PR?

Adds the ability to clip an audio.

#### Why?

Which problem does the PR fix?

#### Example Usage

```php
$audio = $ffmpeg->open('audio.mp3');

// Now we can do
$audio->filters()->clip(FFMpeg\Coordinate\TimeCode::fromSeconds(0), FFMpeg\Coordinate\TimeCode::fromSeconds(60));
```
#### To Do

- [X] Create tests
- [ ] Documentation

I really want to thank @swordsreversed, since he's the person who gave us the foundation, I could build with.

Additionally, I've added 2 methods to TimeCode, because I thought I need to validate first, wether the second value given is bigger than the first. (...) But I think these methods could be useful in the future, especially when adding a filter which cuts at a position... #workinprogress