### PR TITLE
Codec Testing [need help with tests]

### DIFF
--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use FFMpeg\Driver\FFProbeDriver;
 use FFMpeg\FFProbe\DataMapping\Format;
+use FFMpeg\FFProbe\CodecTester;
 use FFMpeg\FFProbe\Mapper;
 use FFMpeg\FFProbe\MapperInterface;
 use FFMpeg\FFProbe\OptionsTester;
@@ -35,6 +36,12 @@ class FFProbe
 
     /** @var Cache */
     private $cache;
+
+    /**
+     * provides functions to test wether the codec wanted is available
+     * @var CodecTesterInterface
+     */
+    private $codecTester;
     /** @var OptionsTesterInterface */
     private $optionsTester;
     /** @var OutputParserInterface */
@@ -47,6 +54,7 @@ class FFProbe
     public function __construct(FFProbeDriver $ffprobe, Cache $cache)
     {
         $this->ffprobe = $ffprobe;
+        $this->codecTester = new CodecTester($ffprobe, $cache);
         $this->optionsTester = new OptionsTester($ffprobe, $cache);
         $this->parser = new OutputParser();
         $this->mapper = new Mapper();
@@ -91,6 +99,26 @@ class FFProbe
         $this->ffprobe = $ffprobe;
 
         return $this;
+    }
+
+    /**
+     * @param CodecTesterInterface $tester
+     *
+     * @return FFProbe
+     */
+    public function setCodecTester(CodecTesterInterface $tester)
+    {
+        $this->optionsTester = $tester;
+
+        return $this;
+    }
+
+    /**
+     * @return CodecTesterInterface
+     */
+    public function getCodecTester()
+    {
+        return $this->codecTester;
     }
 
     /**

--- a/src/FFMpeg/FFProbe/CodecTester.php
+++ b/src/FFMpeg/FFProbe/CodecTester.php
@@ -19,7 +19,7 @@ use FFMpeg\Exception\RuntimeException;
 /**
  * Ensures that the wanted codec is supported by the system
  */
-class CodecTester implements OptionsTesterInterface
+class CodecTester implements CodecTesterInterface
 {
     /** @var FFProbeDriver */
     private $ffprobe;

--- a/src/FFMpeg/FFProbe/CodecTester.php
+++ b/src/FFMpeg/FFProbe/CodecTester.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\FFProbe;
+
+use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use Doctrine\Common\Cache\Cache;
+use FFMpeg\Driver\FFProbeDriver;
+use FFMpeg\Exception\RuntimeException;
+
+/**
+ * Ensures that the wanted codec is supported by the system
+ */
+class CodecTester implements OptionsTesterInterface
+{
+    /** @var FFProbeDriver */
+    private $ffprobe;
+    /** @var Cache */
+    private $cache;
+
+    public function __construct(FFProbeDriver $ffprobe, Cache $cache)
+    {
+        $this->ffprobe = $ffprobe;
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($name)
+    {
+        $id = sprintf('--enable-%s', $name);
+
+        if ($this->cache->contains($id)) {
+            return $this->cache->fetch($id);
+        }
+
+        $output = $this->retrieveHelpOutput();
+
+        $ret = (Boolean) preg_match('/^(?:\s{3})\s'.$id.'/m', $output);
+
+        $this->cache->save($id, $ret);
+
+        return $ret;
+    }
+
+    private function retrieveHelpOutput()
+    {
+        $id = 'build';
+
+        if ($this->cache->contains($id)) {
+            return $this->cache->fetch($id);
+        }
+
+        try {
+            $output = $this->ffprobe->command(array('-buildconf'));
+        } catch (ExecutionFailureException $e) {
+            throw new RuntimeException('Your FFProbe version is too old and does not support `-help` option, please upgrade.', $e->getCode(), $e);
+        }
+
+        $this->cache->save($id, $output);
+
+        return $output;
+    }
+}

--- a/src/FFMpeg/FFProbe/CodecTester.php
+++ b/src/FFMpeg/FFProbe/CodecTester.php
@@ -63,7 +63,7 @@ class CodecTester implements OptionsTesterInterface
         try {
             $output = $this->ffprobe->command(array('-buildconf'));
         } catch (ExecutionFailureException $e) {
-            throw new RuntimeException('Your FFProbe version is too old and does not support `-help` option, please upgrade.', $e->getCode(), $e);
+            throw new RuntimeException('Your FFProbe version is too old and does not support `-buildconf` option, please upgrade.', $e->getCode(), $e);
         }
 
         $this->cache->save($id, $output);

--- a/src/FFMpeg/FFProbe/CodecTesterInterface.php
+++ b/src/FFMpeg/FFProbe/CodecTesterInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\FFProbe;
+
+interface CodecTesterInterface
+{
+    /**
+     * Tells if the given codec is supported by ffmpeg.
+     *
+     * @param string $name
+     *
+     * @return Boolean
+     */
+    public function has($name);
+}

--- a/src/FFMpeg/Format/Audio/DefaultAudio.php
+++ b/src/FFMpeg/Format/Audio/DefaultAudio.php
@@ -47,6 +47,12 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     }
 
     /**
+     * Returns an array with the supported audio codecs for this format
+     * @return string[]
+     */
+    abstract public function getAvailableAudioCodecs();
+
+    /**
      * Sets the audio codec, Should be in the available ones, otherwise an
      * exception is thrown.
      *

--- a/src/FFMpeg/Format/Audio/DefaultAudio.php
+++ b/src/FFMpeg/Format/Audio/DefaultAudio.php
@@ -47,8 +47,7 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     }
 
     /**
-     * Returns an array with the supported audio codecs for this format
-     * @return string[]
+     * @inheritDoc
      */
     abstract public function getAvailableAudioCodecs();
 

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -69,8 +69,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     }
 
     /**
-     * Returns an array with the supported video codecs for this format
-     * @return string[]
+     * @inheritDoc
      */
     abstract public function getAvailableVideoCodecs();
 

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -69,6 +69,12 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     }
 
     /**
+     * Returns an array with the supported video codecs for this format
+     * @return string[]
+     */
+    abstract public function getAvailableVideoCodecs();
+
+    /**
      * Sets the video codec, Should be in the available ones, otherwise an
      * exception is thrown.
      *

--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -22,7 +22,7 @@ class X264 extends DefaultVideo
     /** @var integer */
     private $passes = 2;
 
-    public function __construct($audioCodec = 'libfaac', $videoCodec = 'libx264')
+    public function __construct($audioCodec = 'libmp3lame', $videoCodec = 'libx264')
     {
         $this
             ->setAudioCodec($audioCodec)

--- a/src/FFMpeg/Format/VideoInterface.php
+++ b/src/FFMpeg/Format/VideoInterface.php
@@ -49,9 +49,8 @@ interface VideoInterface extends AudioInterface
     public function supportBFrames();
 
     /**
-     * Returns the list of available video codecs for this format.
-     *
-     * @return array
+     * Returns an array with the supported video codecs for this format
+     * @return string[]
      */
     public function getAvailableVideoCodecs();
 
@@ -61,4 +60,10 @@ interface VideoInterface extends AudioInterface
      * @return array
      */
     public function getAdditionalParameters();
+
+    /**
+     * Returns an array with the supported audio codecs for this format
+     * @return string[]
+     */
+    public function getAvailableAudioCodecs();
 }

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -75,8 +75,14 @@ class Audio extends AbstractStreamableMedia
         if ($this->driver->getConfiguration()->has('ffmpeg.threads')) {
             $filters->add(new SimpleFilter(array('-threads', $this->driver->getConfiguration()->get('ffmpeg.threads'))));
         }
-        if (null !== $format->getAudioCodec()) {
-            $filters->add(new SimpleFilter(array('-acodec', $format->getAudioCodec())));
+
+        $audioCodec = $format->getAudioCodec();
+        if (null !== $audioCodec) {
+            if(!$this->ffprobe->getCodecTester()->has($audioCodec)) {
+                throw new \InvalidArgumentException('The given audio codec ' . $audioCodec . ' is not supported by this machine!');
+            }
+
+            $filters->add(new SimpleFilter(array('-acodec', $audioCodec)));
         }
 
         foreach ($filters as $filter) {
@@ -104,7 +110,7 @@ class Audio extends AbstractStreamableMedia
     }
 
     /**
-     * Gets the waveform of the video.
+     * Gets the waveform of the media.
      *
      * @param  integer $width
      * @param  integer $height

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -70,13 +70,23 @@ class Video extends Audio
             $filters->add(new SimpleFilter(array('-threads', $this->driver->getConfiguration()->get('ffmpeg.threads'))));
         }
         if ($format instanceof VideoInterface) {
-            if (null !== $format->getVideoCodec()) {
-                $filters->add(new SimpleFilter(array('-vcodec', $format->getVideoCodec())));
+            $videoCodec = $format->getVideoCodec();
+            if (null !== $videoCodec) {
+                if(!$this->ffprobe->getCodecTester()->has($videoCodec)) {
+                    throw new \InvalidArgumentException('The given video codec ' . $videoCodec . ' is not supported by this machine!');
+                }
+
+                $filters->add(new SimpleFilter(array('-vcodec', $videoCodec)));
             }
         }
         if ($format instanceof AudioInterface) {
-            if (null !== $format->getAudioCodec()) {
-                $filters->add(new SimpleFilter(array('-acodec', $format->getAudioCodec())));
+            $audioCodec = $format->getAudioCodec();
+            if (null !== $audioCodec) {
+                if(!$this->ffprobe->getCodecTester()->has($audioCodec)) {
+                    throw new \InvalidArgumentException('The given audio codec ' . $audioCodec . ' is not supported by this machine!');
+                }
+
+                $filters->add(new SimpleFilter(array('-acodec', $audioCodec)));
             }
         }
 

--- a/tests/Unit/FFProbe/CodecTesterTest.php
+++ b/tests/Unit/FFProbe/CodecTesterTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\FFProbe;
+
+use Tests\FFMpeg\Unit\TestCase;
+
+class CodecTesterTest extends TestCase
+{
+    // TODO: Do we need to write tests?
+
+    public function testDummy() {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Unit/Media/AudioTest.php
+++ b/tests/Unit/Media/AudioTest.php
@@ -169,6 +169,8 @@ class AudioTest extends AbstractStreamableTestCase
                 $capturedListeners = $listeners;
             }));
 
+        // TODO: Need help to fix this test, create mock for codectester?
+
         $outputPathfile = '/target/file';
 
         $audio = new Audio(__FILE__, $driver, $ffprobe);

--- a/tests/Unit/Media/AudioTest.php
+++ b/tests/Unit/Media/AudioTest.php
@@ -159,6 +159,17 @@ class AudioTest extends AbstractStreamableTestCase
                 ->method('get');
         }
 
+        $codecTester = $this->getCodecTesterMock();
+
+        $ffprobe->expects($this->any())
+            ->method('getCodecTester')
+            ->will($this->returnValue($codecTester));
+
+        // We're in test, of course the codecs won't be available at all
+        $codecTester->expects($this->any())
+            ->method('has')
+            ->will($this->returnValue(true));
+
         $capturedCommand = $capturedListeners = null;
 
         $driver->expects($this->once())

--- a/tests/Unit/Media/VideoTest.php
+++ b/tests/Unit/Media/VideoTest.php
@@ -182,6 +182,17 @@ class VideoTest extends AbstractStreamableTestCase
         $capturedCommands = array();
         $capturedListeners = null;
 
+        $codecTester = $this->getCodecTesterMock();
+
+        $ffprobe->expects($this->any())
+            ->method('getCodecTester')
+            ->will($this->returnValue($codecTester));
+
+        // We're in test, of course the codecs won't be available at all
+        $codecTester->expects($this->any())
+            ->method('has')
+            ->will($this->returnValue(true));
+
         $driver->expects($this->exactly(count($expectedCommands)))
             ->method('command')
             ->with($this->isType('array'), false, $this->anything())

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -168,4 +168,10 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
         return $FormatInterface;
     }
+
+    public function getCodecTesterMock() {
+        return $this->getMockBuilder('FFMpeg\FFProbe\CodecTester')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | yes/no
| BC breaks?         | maybe, libfaac won't be used internally, but it's known for problems
| Deprecations?      | no
| Fixed tickets      | fixes #322 
| Related issues/PRs | #322 , #310 
| License            | MIT


#### What's in this PR?
Basically: Before saving a codec it will be checked wether it is available on the machine. It caches the result of the queries.
The default mp3 codec is now libmp3lame.
I'd modified some tests, so they do not fail on my machine. (Except the one where it is used strictly.)
But I'm still in need of some help, I'm not that experienced in phpunit and the manual wasn't that helpful on this topic. Any point of direction would be cool! 😆 

#### To Do

- [ ] Create tests [help wanted]
