### PR TITLE
Set a default duration to 0 to fix issue 333

### DIFF
--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -79,6 +79,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     public function apply(Video $video, VideoInterface $format)
     {
         $commands = array();
+        $duration = 0;
 
         try {
             // Get the duration of the video
@@ -105,7 +106,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
 
             // Set the number of digits to use in the exported filenames
             $nbImages = ceil( $duration * $nbFramesPerSecond );
-            
+
             if($nbImages < 100)
                 $nbDigitsInFileNames = "02";
             elseif($nbImages < 1000)


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #333 
| Related issues/PRs | #333
| License            | MIT

#### What's in this PR?

A fix to the issue 333.
We set a default duration variable to 0 in the ExtractMultipleFramesFilter.php.

#### Why?

It generated an exception in some cases.