### PR TITLE
Video profile and level

### DIFF
--- a/src/FFMpeg/Format/Profile.php
+++ b/src/FFMpeg/Format/Profile.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Format;
+
+interface Profile {
+
+    const HIGH = 'high';
+
+    const MAIN = 'main';
+
+    const BASELINE = 'baseline';
+
+}

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -32,8 +32,48 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     /** @var Integer */
     protected $modulus = 16;
 
+    /** @var string */
+    private $profile = Profile::MAIN;
+
+    /** @var float */
+    private $level = 3.1;
+
     /** @var Array */
     protected $additionalParamaters;
+
+    /**
+     * Sets the profile of this video
+     * @var string  $profile    must be one of `baseline`, `main` or `high`
+     * @throws \InvalidArgumentException
+     */
+    public function setProfile(string $profile) {
+        switch($profile) {
+            case Profile::BASELINE:
+            case Profile::MAIN:
+            case Profile::HIGH:
+            // these are fine
+            break;
+            default:
+                throw new \InvalidArgumentException('Invalid profile given! Must be one of `baseline`, `main` or `high`!');
+        }
+        $this->profile = $profile;
+    }
+
+    /**
+     * Returns the current profile
+     * @return string
+     */
+    public function getProfile() {
+        return $this->profile;
+    }
+
+    /**
+     * Sets the given level
+     * @param   float   $level  The level(for example: 3.0, 3.1, 4.0, 4.1)
+     */
+    public function setLevel(float $level) {
+        $this->level = $level;
+    }
 
     /**
      * {@inheritdoc}

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -76,6 +76,14 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     }
 
     /**
+     * Returns the level
+     * @return float
+     */
+    public function getLevel() {
+        return $this->level;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getKiloBitrate()

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -72,6 +72,8 @@ class Video extends Audio
         if ($format instanceof VideoInterface) {
             if (null !== $format->getVideoCodec()) {
                 $filters->add(new SimpleFilter(array('-vcodec', $format->getVideoCodec())));
+                $filters->add(new SimpleFilter(array('-vprofile', $format->getProfile())));
+                $filters->add(new SimpleFilter(array('-level', $format->getLevel())));
             }
         }
         if ($format instanceof AudioInterface) {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | I hope no.
| Deprecations?      | no
| Fixed tickets      | fixes #282
| Related issues/PRs | #302
| License            | MIT

#### What's in this PR?

The availability to set the level and  the profile of a specific video.

#### Why?

Making it possible to encode videos in ways, that old mobiles do understand(for example apple devices)

#### BC Breaks/Deprecations

I hope there are no. I'd added default values.

#### To Do

- [ ] Check wether we break tests
- [ ] Determine wether we need to add new tests. @romainneutron ?
