### PR TITLE
Fix missing audio artwork metadata on multiple exports

### DIFF
--- a/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
+++ b/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
- 
+
 namespace FFMpeg\Filters\Audio;
 
 use FFMpeg\Filters\Audio\AudioFilterInterface;
@@ -16,7 +16,7 @@ use FFMpeg\Format\AudioInterface;
 use FFMpeg\Media\Audio;
 
 class AddMetadataFilter implements AudioFilterInterface
-{	
+{
 	/** @var Array */
 	private $metaArr;
 	/** @var Integer */
@@ -36,17 +36,20 @@ class AddMetadataFilter implements AudioFilterInterface
 
 	public function apply(Audio $audio, AudioInterface $format)
 	{
-		if (is_null($this->metaArr))
+		$meta = $this->metaArr;
+
+		if (is_null($meta)) {
 			return ['-map_metadata', '-1', '-vn'];
+		}
 
 		$metadata = [];
 
-		if (array_key_exists("artwork", $this->metaArr)) {
-			array_push($metadata, "-i", $this->metaArr['artwork'], "-map", "0", "-map", "1");
-			unset($this->metaArr['artwork']);
+		if (array_key_exists("artwork", $meta)) {
+			array_push($metadata, "-i", $meta['artwork'], "-map", "0", "-map", "1");
+			unset($meta['artwork']);
 		}
 
-		foreach ($this->metaArr as $k => $v) {
+		foreach ($meta as $k => $v) {
 			array_push($metadata, "-metadata", "$k=$v");
 		}
 

--- a/tests/Unit/Filters/Audio/AudioMetadataTest.php
+++ b/tests/Unit/Filters/Audio/AudioMetadataTest.php
@@ -41,6 +41,7 @@ class AudioMetadataTest extends TestCase
         $filters = new AudioFilters($audio);
         $filters->addMetadata(array('genre' => 'Some Genre', 'artwork' => "/path/to/file.jpg"));
         $this->assertEquals(array(0 => "-i", 1 => "/path/to/file.jpg", 2 => "-map", 3 => "0", 4 => "-map", 5 => "1", 6 => "-metadata", 7 => "genre=Some Genre"), $capturedFilter->apply($audio, $format));
+        $this->assertEquals(array(0 => "-i", 1 => "/path/to/file.jpg", 2 => "-map", 3 => "0", 4 => "-map", 5 => "1", 6 => "-metadata", 7 => "genre=Some Genre"), $capturedFilter->apply($audio, $format));
     }
 
     public function testRemoveMetadata()


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | -
| Related issues/PRs | #281 
| License            | MIT

#### What's in this PR?

This commit fixes this issue by copying (by value) the `metaArr`
property to a local variable each time the filter is applied.

#### Why?

When the `AddMetadataFilter` is applied on an `Audio` media, the `artwork`
parameter was being unset from the `metaArr` array.

Saving the same `Audio` instance multiple times generated the
correct commands for the first export, but the subsequent commands were
missing the `artwork` parameter.

#### Example Usage

```php
$ffmpeg = new FFMpeg\FFMpeg::create();

$audio = $ffmpeg->open('track.wav');

$audio->addMetadata([
    "title" => "Some Title",
    "album" => "Some Album",
    "artwork" => "/path/to/some/file.jpg"
]);

// Now we can do

$mp3 = new FFMpeg\Format\Audio\Mp3();

// The first time we export a 320kbps MP3

$mp3->setAudioKiloBitrate(320);
$audio->save($mp3, 'track-hd.mp3');

// The second time we export a 128kbps MP3

$mp3->setAudioKiloBitrate(128);
$audio->save($mp3, 'track-sd.mp3');