### PR TITLE
Support resize and watermark in ordering.

### DIFF
--- a/src/FFMpeg/Filters/Video/ResizeFilter.php
+++ b/src/FFMpeg/Filters/Video/ResizeFilter.php
@@ -98,9 +98,6 @@ class ResizeFilter implements VideoFilterInterface
         if (null !== $dimensions) {
             $dimensions = $this->getComputedDimensions($dimensions, $format->getModulus());
 
-            // $commands[] = '-s';
-            // $commands[] = $dimensions->getWidth() . 'x' . $dimensions->getHeight();
-            
             // Using Filter to have ordering
             $commands[] = '-vf';
             $commands[] = '[in]scale=' . $dimensions->getWidth() . ':' . $dimensions->getHeight() . ' [out]';

--- a/src/FFMpeg/Filters/Video/ResizeFilter.php
+++ b/src/FFMpeg/Filters/Video/ResizeFilter.php
@@ -98,8 +98,13 @@ class ResizeFilter implements VideoFilterInterface
         if (null !== $dimensions) {
             $dimensions = $this->getComputedDimensions($dimensions, $format->getModulus());
 
-            $commands[] = '-s';
-            $commands[] = $dimensions->getWidth() . 'x' . $dimensions->getHeight();
+            // $commands[] = '-s';
+            // $commands[] = $dimensions->getWidth() . 'x' . $dimensions->getHeight();
+            
+            // Using Filter to have ordering
+            $commands[] = '-vf';
+            $commands[] = '[in]scale=' . $dimensions->getWidth() . ':' . $dimensions->getHeight() . ' [out]';
+            
         }
 
         return $commands;

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -129,6 +129,46 @@ class Video extends Audio
             }
         }
 
+        // Merge Filters into one command
+        $videoFilterVars = $videoFilterProcesses = [];
+        for($i=0;$i<count($commands);$i++) {
+            $command = $commands[$i];
+            if ( $command == '-vf' ) {
+                $commandSplits = explode(";", $commands[$i + 1]);
+                foreach($commandSplits as $commandSplit) {
+                    $command = trim($commandSplit);
+                    if ( preg_match("/^\[[^\]]+\](.*?)\[[^\]]+\]$/is", $command, $match) ) {
+                        $videoFilterProcesses[] = $match[1];
+                    } else {
+                        $videoFilterVars[] = $command;
+                    }                
+                }
+                unset($commands[$i]);
+                unset($commands[$i + 1]);
+                $i++;
+            }
+        }
+        $videoFilterCommands = $videoFilterVars;
+        $lastInput = 'in';
+        foreach($videoFilterProcesses as $i => $process) {
+            $command = '[' . $lastInput .']';
+            $command .= $process;
+            $lastInput = 'p' . $i;
+            if ( $i == count($videoFilterProcesses) - 1 ) {
+                $command .= '[out]';
+            } else {
+                $command .= '[' . $lastInput . ']';
+            }
+            
+            $videoFilterCommands[] = $command;
+        }
+        $videoFilterCommand = implode(";", $videoFilterCommands);
+        
+        if ( $videoFilterCommand ) {
+            $commands[] = '-vf';
+            $commands[] = $videoFilterCommand;
+        }
+        
         $fs = FsManager::create();
         $fsId = uniqid('ffmpeg-passes');
         $passPrefix = $fs->createTemporaryDirectory(0777, 50, $fsId) . '/' . uniqid('pass-');

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -138,7 +138,7 @@ class Video extends Audio
                 if ( count($commandSplits) == 1 ) {
                     $commandSplit = $commandSplits[0];
                     $command = trim($commandSplit);
-                    if ( !preg_match("/^\[in\](.*?)\[out\]$/is", $command, $match) ) {
+                    if ( preg_match("/^\[in\](.*?)\[out\]$/is", $command, $match) ) {
                         $videoFilterProcesses[] = $match[1];
                     } else {
                         $videoFilterProcesses[] = $command;   

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -135,13 +135,23 @@ class Video extends Audio
             $command = $commands[$i];
             if ( $command == '-vf' ) {
                 $commandSplits = explode(";", $commands[$i + 1]);
-                foreach($commandSplits as $commandSplit) {
+                if ( count($commandSplits) == 1 ) {
+                    $commandSplit = $commandSplits[0];
                     $command = trim($commandSplit);
-                    if ( preg_match("/^\[[^\]]+\](.*?)\[[^\]]+\]$/is", $command, $match) ) {
+                    if ( !preg_match("/^\[in\](.*?)\[out\]$/is", $command, $match) ) {
                         $videoFilterProcesses[] = $match[1];
                     } else {
-                        $videoFilterVars[] = $command;
-                    }                
+                        $videoFilterProcesses[] = $command;   
+                    }
+                } else {
+                    foreach($commandSplits as $commandSplit) {
+                        $command = trim($commandSplit);
+                        if ( preg_match("/^\[[^\]]+\](.*?)\[[^\]]+\]$/is", $command, $match) ) {
+                            $videoFilterProcesses[] = $match[1];
+                        } else {
+                            $videoFilterVars[] = $command;
+                        }                
+                    }
                 }
                 unset($commands[$i]);
                 unset($commands[$i + 1]);

--- a/tests/Unit/Filters/Video/ResizeFilterTest.php
+++ b/tests/Unit/Filters/Video/ResizeFilterTest.php
@@ -42,34 +42,34 @@ class ResizeFilterTest extends TestCase
     public function provideDimensions()
     {
         return array(
-            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_FIT, 640, 480, 2, array('-s', '320x240')),
-            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_INSET, 640, 480, 2, array('-s', '320x240')),
-            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 640, 480, 2, array('-s', '320x240')),
-            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 640, 480, 2, array('-s', '320x240')),
+            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_FIT, 640, 480, 2, array('-vf', '[in]scale=320:240 [out]')),
+            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_INSET, 640, 480, 2, array('-vf', '[in]scale=320:240 [out]')),
+            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 640, 480, 2, array('-vf', '[in]scale=320:240 [out]')),
+            array(new Dimension(320, 240), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 640, 480, 2, array('-vf', '[in]scale=320:240 [out]')),
 
-            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_FIT, 320, 240, 2, array('-s', '640x480')),
-            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_INSET, 320, 240, 2, array('-s', '640x480')),
-            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 320, 240, 2, array('-s', '640x480')),
-            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 320, 240, 2, array('-s', '640x480')),
+            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_FIT, 320, 240, 2, array('-vf', '[in]scale=640:480 [out]')),
+            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_INSET, 320, 240, 2, array('-vf', '[in]scale=640:480 [out]')),
+            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 320, 240, 2, array('-vf', '[in]scale=640:480 [out]')),
+            array(new Dimension(640, 480), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 320, 240, 2, array('-vf', '[in]scale=640:480 [out]')),
 
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_FIT, 1280, 720, 2, array('-s', '640x360')),
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_INSET, 1280, 720, 2, array('-s', '640x360')),
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 1280, 720, 2, array('-s', '640x360')),
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 1280, 720, 2, array('-s', '640x360')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_FIT, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_INSET, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
 
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_FIT, 1280, 720, 2, array('-s', '640x360')),
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_INSET, 1280, 720, 2, array('-s', '640x360')),
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 1280, 720, 2, array('-s', '640x360')),
-            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 1280, 720, 2, array('-s', '640x360')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_FIT, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_INSET, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
+            array(new Dimension(640, 360), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 1280, 720, 2, array('-vf', '[in]scale=640:360 [out]')),
 
             // test non standard dimension
-            array(new Dimension(700, 150), ResizeFilter::RESIZEMODE_INSET, 123, 456, 2, array('-s', '62x150'), true),
-            array(new Dimension(700, 150), ResizeFilter::RESIZEMODE_INSET, 123, 456, 2, array('-s', '40x150'), false),
+            array(new Dimension(700, 150), ResizeFilter::RESIZEMODE_INSET, 123, 456, 2, array('-vf', '[in]scale=62:150 [out]'), true),
+            array(new Dimension(700, 150), ResizeFilter::RESIZEMODE_INSET, 123, 456, 2, array('-vf', '[in]scale=40:150 [out]'), false),
 
-            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_FIT, 640, 480, 2, array('-s', '320x320')),
-            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_INSET, 640, 480, 2, array('-s', '320x240')),
-            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 640, 480, 2, array('-s', '320x240')),
-            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 640, 480, 2, array('-s', '426x320')),
+            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_FIT, 640, 480, 2, array('-vf', '[in]scale=320:320 [out]')),
+            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_INSET, 640, 480, 2, array('-vf', '[in]scale=320:240 [out]')),
+            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_SCALE_HEIGHT, 640, 480, 2, array('-vf', '[in]scale=320:240 [out]')),
+            array(new Dimension(320, 320), ResizeFilter::RESIZEMODE_SCALE_WIDTH, 640, 480, 2, array('-vf', '[in]scale=426:320 [out]')),
         );
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #308
| License            | MIT

#### What's in this PR?

Support resize and watermark in ordering.

#### Why?

Cannot resize image then adding watermark. The ordering is ignored.

#### Example Usage

The following codes will have different results.

```php
$ffmpeg = FFMpeg\FFMpeg::create();
$video = $ffmpeg->open($filepath);
$filters = $video->filters();
$filters->resize(new FFMpeg\Coordinate\Dimension($width, $height), FFMpeg\Filters\Video\ResizeFilter::RESIZEMODE_SCALE_HEIGHT, false);
$filters->watermark($watermarkPath, array(
	'position' => 'relative',
	'bottom' => 0,
	'left' => 0,
));
$video->save(new FFMpeg\Format\Video\X264(), $videoPath);
```

```php
$ffmpeg = FFMpeg\FFMpeg::create();
$video = $ffmpeg->open($filepath);
$filters = $video->filters();
$filters->watermark($watermarkPath, array(
	'position' => 'relative',
	'bottom' => 0,
	'left' => 0,
));
$filters->resize(new FFMpeg\Coordinate\Dimension($width, $height), FFMpeg\Filters\Video\ResizeFilter::RESIZEMODE_SCALE_HEIGHT, false);
$video->save(new FFMpeg\Format\Video\X264(), $videoPath);
```

#### To Do

- [x] Create tests
