### PR TITLE
The variable currentSize in AbstractProgressListener.php MUST be an integer. Test it and convert it if needed.

### DIFF
--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -179,6 +179,12 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
 
         if ($this->lastOutput !== null) {
             $delta = $currentTime - $this->lastOutput;
+
+            // Check the type of the currentSize variable and convert it to an integer if needed.
+            if(!is_numeric($currentSize)) {
+                $currentSize = (int)$currentSize;
+            }
+
             $deltaSize = $currentSize - $this->currentSize;
             $rate = $deltaSize * $delta;
             if ($rate > 0) {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #339 
| Related issues/PRs | #339 
| License            | MIT

#### What's in this PR?

This PR changes the way we use the variable currentSize in AbstractProgressListener.php. We first check to see if it's an integer. If not, we convert it.

#### Why?

With PHP7, when this variable was not a numeric value, an error was thrown.
