### PR TITLE
vbr encoding for audio stream and custom filter for decoding audio

### DIFF
--- a/src/FFMpeg/Filters/Audio/AudioFilters.php
+++ b/src/FFMpeg/Filters/Audio/AudioFilters.php
@@ -71,4 +71,18 @@ class AudioFilters
 
         return $this;
     }
+
+    /**
+     * Add custom filter.
+     *
+     * @param $params
+     * @param int $priority
+     * @return $this
+     */
+    public function simple($params, $priority = 0)
+    {
+        $this->media->addFilter(new SimpleFilter($params, $priority));
+
+        return $this;
+    }
 }

--- a/src/FFMpeg/Format/Audio/DefaultAudio.php
+++ b/src/FFMpeg/Format/Audio/DefaultAudio.php
@@ -30,12 +30,40 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     /** @var integer */
     protected $audioChannels = null;
 
+    /** @var bool */
+    protected $enableVbrEncoding = false;
+
+    /** @var integer */
+    protected $vbrEncodingQuality = 3;
+
     /**
      * {@inheritdoc}
      */
     public function getExtraParams()
     {
         return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVbrEncodingQuality()
+    {
+        return $this->vbrEncodingQuality;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setVbrEncodingQuality($value)
+    {
+        if ($value < 1 || $value > 9) {
+            throw new InvalidArgumentException('Wrong vbr encoding quality value');
+        }
+
+        $this->vbrEncodingQuality = (int) $value;
+
+        return $this;
     }
 
     /**

--- a/src/FFMpeg/Format/AudioInterface.php
+++ b/src/FFMpeg/Format/AudioInterface.php
@@ -39,4 +39,18 @@ interface AudioInterface extends FormatInterface
      * @return array
      */
     public function getAvailableAudioCodecs();
+
+    /**
+     * Get enable vbr encoding parametr
+     *
+     * @return bool
+     */
+    public function getEnableVbrEncoding();
+
+    /**
+     * Set vbr encoding quality
+     *
+     * @return integer
+     */
+    public function getVbrEncodingQuality();
 }

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -84,8 +84,13 @@ class Audio extends AbstractStreamableMedia
         }
 
         if (null !== $format->getAudioKiloBitrate()) {
-            $commands[] = '-b:a';
-            $commands[] = $format->getAudioKiloBitrate() . 'k';
+            if (!$format->getEnableVbrEncoding()) {
+                $commands[] = '-b:a';
+                $commands[] = $format->getAudioKiloBitrate() . 'k';
+            } else {
+                $commands[] = '-q:a';
+                $commands[] = $format->getVbrEncodingQuality();
+            }
         }
         if (null !== $format->getAudioChannels()) {
             $commands[] = '-ac';

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -111,8 +111,13 @@ class Video extends Audio
 
         if ($format instanceof AudioInterface) {
             if (null !== $format->getAudioKiloBitrate()) {
-                $commands[] = '-b:a';
-                $commands[] = $format->getAudioKiloBitrate() . 'k';
+                if (!$format->getEnableVbrEncoding()) {
+                    $commands[] = '-b:a';
+                    $commands[] = $format->getAudioKiloBitrate() . 'k';
+                } else {
+                    $commands[] = '-q:a';
+                    $commands[] = $format->getVbrEncodingQuality();
+                }
             }
             if (null !== $format->getAudioChannels()) {
                 $commands[] = '-ac';


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

The availability to use vbr encoding for decoding audio with custom quality and also add feature to add custom filters for decoding audio using SimpleFilter.

#### Why?

Make possible to use vbr encoding for decoding audio and also add feature to add custom filters for decoding audio, for example, resize album image.

#### Example Usage

```php
$ffmpeg = \FFMpeg\FFMpeg::create([]);
$audio = $ffmpeg->open('/path/to/audio.mp3');

$format = new \FFMpeg\Format\Audio\Mp3();

//Example for custom filter for resize album image
$audio->filters()->simple(['-s', '500x500']);
$foo = new Foo();

//Example for enable vbr encoding for audio file
$format
    ->setEnableVbrEncoding(true)
    ->setVbrEncodingQuality(5);
```

#### To Do

- [ ] Create tests
- [ ] Add documentation to README.MD
