### PR TITLE
New Video::getStream() function (fixes #13)

### DIFF
--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -50,16 +50,13 @@ class Video extends Audio
     }
 
     /**
-     * Exports the video in the desired format, applies registered filters.
+     * Get ffmpeg commands used to export the video.
      *
-     * @param FormatInterface $format
-     * @param string          $outputPathfile
+     * @param  FormatInterface $format
      *
-     * @return Video
-     *
-     * @throws RuntimeException
+     * @return array
      */
-    public function save(FormatInterface $format, $outputPathfile)
+    private function getCommands(FormatInterface $format)
     {
         $commands = array('-y', '-i', $this->pathfile);
 
@@ -128,6 +125,38 @@ class Video extends Audio
                 }
             }
         }
+
+        return $commands;
+    }
+
+    /**
+     * Return a popen stream that exports the video in the desired format.
+     *
+     * @param  FormatInterface $format
+     *
+     * @return resource
+     */
+    public function getStream(FormatInterface $format)
+    {
+        $commands = $this->getCommands($format);
+        $commands[] = 'pipe:1';
+
+        return popen($this->driver->getProcessBuilderFactory()->create($commands)->getCommandLine(), 'r');
+    }
+
+    /**
+     * Exports the video in the desired format, applies registered filters.
+     *
+     * @param FormatInterface $format
+     * @param string          $outputPathfile
+     *
+     * @return Video
+     *
+     * @throws RuntimeException
+     */
+    public function save(FormatInterface $format, $outputPathfile)
+    {
+        $commands = $this->getCommands($format);
 
         $fs = FsManager::create();
         $fsId = uniqid('ffmpeg-passes');


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #13
| Related issues/PRs | #272
| License            | MIT

#### What's in this PR?

This PR adds a new Video::getStream() function that returns a popen stream running the ffmpeg command through a pipe.

#### Why?

This allows streaming the converted video to the browser or to various other libraries that support streams.

#### Example Usage

```php
$ffmpeg = \FFMpeg\FFMpeg::create();
$video = $ffmpeg->open(__DIR__.'/vendor/php-ffmpeg/php-ffmpeg/tests/files/Test.ogv');
$stream = $video->getStream(new \FFMpeg\Format\Video\WebM());
```

#### To Do

- [ ] Create tests
- [ ] Check if the format supports streams (not sure how to do that)
