### PR TITLE
Added missing use of audio_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ $video = $ffmpeg->open( 'video.mp4' );
 $audio_format = new FFMpeg\Format\Audio\Mp3();
 
 // Extract the audio into a new file
-$video->save('audio.mp3');
+$video->save($audio_format, 'audio.mp3');
 
 // Set the audio file
 $audio = $ffmpeg->open( 'audio.mp3' );


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Fixes a missing parameter in an example in the Readme

#### Why?

shows the correct use of saving a video as an audio file
