### PR TITLE
support crop with dynamic point

### DIFF
--- a/src/FFMpeg/Coordinate/Point.php
+++ b/src/FFMpeg/Coordinate/Point.php
@@ -16,10 +16,15 @@ class Point
     private $x;
     private $y;
 
-    public function __construct($x, $y)
+    public function __construct($x, $y, $dynamic = false)
     {
-        $this->x = (int) $x;
-        $this->y = (int) $y;
+        if ($dynamic) {
+            $this->x = $x;
+            $this->y = $y;
+        } else {
+            $this->x = (int)$x;
+            $this->y = (int)$y;
+        }
     }
 
     /**

--- a/tests/Unit/Coordinate/PointTest.php
+++ b/tests/Unit/Coordinate/PointTest.php
@@ -13,4 +13,11 @@ class PointTest extends TestCase
         $this->assertEquals(4, $point->getX());
         $this->assertEquals(25, $point->getY());
     }
+
+    public function testDynamicPointGetters()
+    {
+        $point = new Point("t*100", "t", true);
+        $this->assertEquals("t*100", $point->getX());
+        $this->assertEquals("t", $point->getY());
+    }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Support crop video with dynamic point
for example 

```
ffmpeg -i input.mp4 -filter:v "crop=in_w/4:in_h:t*100:0" output.mp4
```

#### Why?

for creating a motion animation from a video, something like dynamic view of a video

#### Example Usage

```php
require __DIR__."/../vendor/autoload.php";

try {
    $ffmpeg = \FFMpeg\FFMpeg::create();
    $video = $ffmpeg->open(__DIR__."/merge_img.mp4");

    $video
        ->filters()
        ->crop(new \FFMpeg\Coordinate\Point("t*100", 0, true), new \FFMpeg\Coordinate\Dimension(200, 600));

    $video->save(new \FFMpeg\Format\Video\X264(), __DIR__."/test.mp4");
~~~

#### To Do

- [ ] Create tests
