### PR TITLE
Add FFProbe#isValid

### DIFF
--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -173,6 +173,25 @@ class FFProbe
     /**
      * @api
      *
+     * Checks wether the given `$pathfile` is considered a valid media file.
+     *
+     * @param string $pathfile
+     * @return bool
+     * @since 0.10.0
+     */
+    public function isValid(string $pathfile)
+    {
+        try {
+            return $this->format($pathfile)->get('duration') > 0;
+        } catch(\Exception $e) {
+            // complete invalid data
+            return false;
+        }
+    }
+
+    /**
+     * @api
+     *
      * Probes the streams contained in a given file.
      *
      * @param string $pathfile

--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -179,7 +179,7 @@ class FFProbe
      * @return bool
      * @since 0.10.0
      */
-    public function isValid(string $pathfile)
+    public function isValid($pathfile)
     {
         try {
             return $this->format($pathfile)->get('duration') > 0;

--- a/tests/Functional/FFProbeTest.php
+++ b/tests/Functional/FFProbeTest.php
@@ -12,10 +12,23 @@ class FFProbeTest extends FunctionalTestCase
         $this->assertGreaterThan(0, count($ffprobe->streams(__DIR__ . '/../files/Audio.mp3')));
     }
 
+    public function testValidateExistingFile()
+    {
+        $ffprobe = FFProbe::create();
+        $this->assertTrue($ffprobe->isValid(__DIR__ . '/../files/sample.3gp'));
+    }
+
+
+    public function testValidateNonExistingFile()
+    {
+        $ffprobe = FFProbe::create();
+        $this->assertFalse($ffprobe->isValid(__DIR__ . '/../files/WrongFile.mp4'));
+    }
+
     /**
      * @expectedException FFMpeg\Exception\RuntimeException
      */
-    public function testProbeOnUnexistantFile()
+    public function testProbeOnNonExistantFile()
     {
         $ffprobe = FFProbe::create();
         $ffprobe->streams('/path/to/no/file');


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | Yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #394 
| License            | MIT

#### What's in this PR?

Makes it possible to validate media using ffmpeg

#### Why?

It's always good to know what you're going to do.

#### Example Usage

```php
$ffprobe = FFProbe::create();
// now we can do
$ffprobe->isValid(__DIR__ . '/../files/WrongFile.mp4');
```

#### To Do

- [ ] Write documentation in readme.
