### PR TITLE
Fixed: the use of [] was killing PHP 5.3 compat

### DIFF
--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -130,7 +130,7 @@ class Video extends Audio
         }
 
         // Merge Filters into one command
-        $videoFilterVars = $videoFilterProcesses = [];
+        $videoFilterVars = $videoFilterProcesses = array();
         for($i=0;$i<count($commands);$i++) {
             $command = $commands[$i];
             if ( $command == '-vf' ) {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | N/A
| Related issues/PRs | N/A
| License            | MIT

#### What's in this PR?

A very small fix to convert the use of [] into array()

#### Why?

The use of [] prevented PHP 5.3 compatibility.  Fixed that.
