### PR TITLE
Added color option to waveform generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.phar
 composer.lock
 phpunit.xml
 sami.phar
+.idea/

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ documentation below for more information.
 The ouput file MUST use the PNG extension.
 
 ```php
-$waveform = $audio->waveform(640, 120, ['#00FF00']);
+$waveform = $audio->waveform(640, 120, array('#00FF00'));
 $waveform->save('waveform.png');
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ documentation below for more information.
 The ouput file MUST use the PNG extension.
 
 ```php
-$waveform = $audio->waveform(640, 120);
+$waveform = $audio->waveform(640, 120, ['#00FF00']);
 $waveform->save('waveform.png');
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ You can generate a waveform of an audio file using the `FFMpeg\Media\Audio::wave
 method.
 
 This code returns a `FFMpeg\Media\Waveform` instance.
-You can optionally pass dimensions as arguments, see dedicated
+You can optionally pass dimensions as the first two arguments and an array of hex string colors for ffmpeg to use for the waveform, see dedicated
 documentation below for more information.
 
 The ouput file MUST use the PNG extension.
 
 ```php
-$waveform = $audio->waveform(640, 120, ['#00FF00']);
+$waveform = $audio->waveform(640, 120, ['#00FF00/']);
 $waveform->save('waveform.png');
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ documentation below for more information.
 The ouput file MUST use the PNG extension.
 
 ```php
-$waveform = $audio->waveform(640, 120, ['#00FF00/']);
+$waveform = $audio->waveform(640, 120, ['#00FF00']);
 $waveform->save('waveform.png');
 ```
 

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -110,8 +110,8 @@ class Audio extends AbstractStreamableMedia
      * @param  integer $height
      * @return Waveform
      */
-    public function waveform($width = 640, $height = 120)
+    public function waveform($width = 640, $height = 120, $colors = [Waveform::DEFAULT_COLOR])
     {
-        return new Waveform($this, $this->driver, $this->ffprobe, $width, $height);
+        return new Waveform($this, $this->driver, $this->ffprobe, $width, $height, $colors);
     }
 }

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -108,6 +108,7 @@ class Audio extends AbstractStreamableMedia
      *
      * @param  integer $width
      * @param  integer $height
+     * @param array $colors Array of colors for ffmpeg to use. Color format is #000000 (RGB hex string with #)
      * @return Waveform
      */
     public function waveform($width = 640, $height = 120, $colors = [Waveform::DEFAULT_COLOR])

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -135,7 +135,7 @@ class Audio extends AbstractStreamableMedia
      * @param array $colors Array of colors for ffmpeg to use. Color format is #000000 (RGB hex string with #)
      * @return Waveform
      */
-    public function waveform($width = 640, $height = 120, $colors = [Waveform::DEFAULT_COLOR])
+    public function waveform($width = 640, $height = 120, $colors = array(Waveform::DEFAULT_COLOR))
     {
         return new Waveform($this, $this->driver, $this->ffprobe, $width, $height, $colors);
     }

--- a/src/FFMpeg/Media/Waveform.php
+++ b/src/FFMpeg/Media/Waveform.php
@@ -23,9 +23,14 @@ class Waveform extends AbstractMediaType
     const DEFAULT_COLOR = '#000000';
 
     /** @var Video */
-    private $audio;
-    private $width;
-    private $height;
+    protected $audio;
+    protected $width;
+    protected $height;
+
+    /**
+     * @var array
+     */
+    protected $colors;
 
     public function __construct(Audio $audio, FFMpegDriver $driver, FFProbe $ffprobe, $width, $height, $colors = [self::DEFAULT_COLOR])
     {

--- a/src/FFMpeg/Media/Waveform.php
+++ b/src/FFMpeg/Media/Waveform.php
@@ -12,6 +12,7 @@
 namespace FFMpeg\Media;
 
 use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use FFMpeg\Exception\InvalidArgumentException;
 use FFMpeg\Filters\Waveform\WaveformFilterInterface;
 use FFMpeg\Filters\Waveform\WaveformFilters;
 use FFMpeg\Driver\FFMpegDriver;
@@ -89,7 +90,9 @@ class Waveform extends AbstractMediaType
             if (!preg_match('/^#(?:[0-9a-fA-F]{6})$/', $value))
             {
                 //invalid color
-                unset($colors[$row]);
+                //unset($colors[$row]);
+
+                throw new InvalidArgumentException("The provided color '$value' is invalid");
             }
         }
 

--- a/src/FFMpeg/Media/Waveform.php
+++ b/src/FFMpeg/Media/Waveform.php
@@ -134,7 +134,7 @@ class Waveform extends AbstractMediaType
          * @see http://ffmpeg.org/ffmpeg.html#Main-options
          */
         $commands = array(
-            '-i', $this->pathfile, '-filter_complex',
+            '-y', '-i', $this->pathfile, '-filter_complex',
             'showwavespic=colors='.$this->compileColors().':s='.$this->width.'x'.$this->height,
             '-frames:v', '1'
         );

--- a/src/FFMpeg/Media/Waveform.php
+++ b/src/FFMpeg/Media/Waveform.php
@@ -33,7 +33,7 @@ class Waveform extends AbstractMediaType
      */
     protected $colors;
 
-    public function __construct(Audio $audio, FFMpegDriver $driver, FFProbe $ffprobe, $width, $height, $colors = [self::DEFAULT_COLOR])
+    public function __construct(Audio $audio, FFMpegDriver $driver, FFProbe $ffprobe, $width, $height, $colors = array(self::DEFAULT_COLOR))
     {
         parent::__construct($audio->getPathfile(), $driver, $ffprobe);
         $this->audio = $audio;

--- a/src/FFMpeg/Media/Waveform.php
+++ b/src/FFMpeg/Media/Waveform.php
@@ -79,13 +79,14 @@ class Waveform extends AbstractMediaType
      * example #FFFFFF or #000000. By default the color is set to black. Keep in mind that if you save the waveform
      * as jpg file, it will appear completely black and to avoid this you can set the waveform color to white (#FFFFFF).
      * Saving waveforms to png is strongly suggested.
+     *
      * @param array $colors
      */
     public function setColors(array $colors)
     {
         foreach ($colors as $row => $value)
         {
-            if ($value{0} != '#' || strlen($value) != 7)
+            if (!preg_match_all('/^#(?:[0-9a-fA-F]{6})$/', $value))
             {
                 //invalid color
                 unset($colors[$row]);
@@ -102,6 +103,7 @@ class Waveform extends AbstractMediaType
      * Returns an array of colors that will be passed to ffmpeg to use for waveform generation. Colors are applied ONLY
      * to the waveform. Background cannot be controlled that easily and it is probably easier to save the waveform
      * as a transparent png file and then add background of choice.
+     *
      * @return array
      */
     public function getColors()
@@ -111,6 +113,7 @@ class Waveform extends AbstractMediaType
 
     /**
      * Compiles the selected colors into a string, using a pipe separator.
+     *
      * @return string
      */
     protected function compileColors()

--- a/src/FFMpeg/Media/Waveform.php
+++ b/src/FFMpeg/Media/Waveform.php
@@ -86,7 +86,7 @@ class Waveform extends AbstractMediaType
     {
         foreach ($colors as $row => $value)
         {
-            if (!preg_match_all('/^#(?:[0-9a-fA-F]{6})$/', $value))
+            if (!preg_match('/^#(?:[0-9a-fA-F]{6})$/', $value))
             {
                 //invalid color
                 unset($colors[$row]);

--- a/tests/Unit/Media/WaveformTest.php
+++ b/tests/Unit/Media/WaveformTest.php
@@ -52,7 +52,7 @@ class WaveformTest extends AbstractMediaTestCase
             ->method('command')
             ->with($commands);
 
-        $waveform = new Waveform($this->getAudioMock(__FILE__), $driver, $ffprobe, 640, 120);
+        $waveform = new Waveform($this->getAudioMock(__FILE__), $driver, $ffprobe, 640, 120, ['#FFFFFF']);
         $this->assertSame($waveform, $waveform->save($pathfile));
     }
 
@@ -62,7 +62,7 @@ class WaveformTest extends AbstractMediaTestCase
             array(
                 array(
                     '-i', NULL, '-filter_complex',
-                    'showwavespic=colors=#000000:s=640x120',
+                    'showwavespic=colors=#FFFFFF:s=640x120',
                     '-frames:v', '1',
                 ),
             ),

--- a/tests/Unit/Media/WaveformTest.php
+++ b/tests/Unit/Media/WaveformTest.php
@@ -62,7 +62,7 @@ class WaveformTest extends AbstractMediaTestCase
             array(
                 array(
                     '-i', NULL, '-filter_complex',
-                    'showwavespic=s=640x120',
+                    'showwavespic=colors=#000000:s=640x120',
                     '-frames:v', '1',
                 ),
             ),

--- a/tests/Unit/Media/WaveformTest.php
+++ b/tests/Unit/Media/WaveformTest.php
@@ -61,7 +61,7 @@ class WaveformTest extends AbstractMediaTestCase
         return array(
             array(
                 array(
-                    '-i', NULL, '-filter_complex',
+                    '-y', '-i', NULL, '-filter_complex',
                     'showwavespic=colors=#FFFFFF:s=640x120',
                     '-frames:v', '1',
                 ),


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| License            | MIT

#### What's in this PR?

Added the ability to define color palette for the waveform. The default color is black.

#### Why?

By default ffmpeg uses a mixture of colors (mostly orange) that result in an image that is very difficult for post-processing and downright ugly.

#### Example Usage

```php
$audio->waveform(1280, 200, ['#00FF00']);
//or
$waveform = $audio->waveform(1280, 200);
$waveform->setColors(['#FFFFFF']);
~~~

