### PR TITLE
add `getFinalCommand`

### DIFF
--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -57,7 +57,7 @@ class Audio extends AbstractStreamableMedia
      * @return Audio
      * @throws RuntimeException
      */
-    public function save(FormatInterface $format, string $outputPathfile)
+    public function save(FormatInterface $format, $outputPathfile)
     {
         $listeners = null;
 
@@ -85,7 +85,7 @@ class Audio extends AbstractStreamableMedia
      * @return string
      * @since 0.11.0
      */
-    public function getFinalCommand(FormatInterface $format, string $outputPathfile) {
+    public function getFinalCommand(FormatInterface $format, $outputPathfile) {
         return implode(' ', $this->buildCommand($format, $outputPathfile));
     }
 
@@ -97,7 +97,7 @@ class Audio extends AbstractStreamableMedia
      * @return string[] An array which are the components of the command
      * @since 0.11.0
      */
-    protected function buildCommand(FormatInterface $format, string $outputPathfile) {
+    protected function buildCommand(FormatInterface $format, $outputPathfile) {
         $commands = array('-y', '-i', $this->pathfile);
 
         $filters = clone $this->filters;

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -67,7 +67,7 @@ class Video extends Audio
      * @return Video
      * @throws RuntimeException
      */
-    public function save(FormatInterface $format, string $outputPathfile)
+    public function save(FormatInterface $format, $outputPathfile)
     {
         $passes = $this->buildCommand($format, $outputPathfile);
 
@@ -103,7 +103,7 @@ class Video extends Audio
      * NOTE: This method is different to the Audio's one, because Video is using passes.
      * @inheritDoc
      */
-    public function getFinalCommand(FormatInterface $format, string $outputPathfile) {
+    public function getFinalCommand(FormatInterface $format, $outputPathfile) {
         $finalCommands = array();
 
         foreach($this->buildCommand($format, $outputPathfile) as $pass => $passCommands) {
@@ -121,7 +121,7 @@ class Video extends Audio
      * @inheritDoc
      * @return string[][]
      */
-    protected function buildCommand(FormatInterface $format, string $outputPathfile) {
+    protected function buildCommand(FormatInterface $format, $outputPathfile) {
         $commands = array('-y', '-i', $this->pathfile);
 
         $filters = clone $this->filters;


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | Yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #403 
| Related issues/PRs | #403
| License            | MIT

#### What's in this PR?

The possibility of getting the command that would be executed.

#### Why?

It's useful for debugging purposes. It is intended to not document the function itself, but only use it for debugging purposes.

#### BC Breaks/Deprecations

None.