### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "sami/sami": "~1.0",
         "silex/silex": "~1.0",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-0": {

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -3,8 +3,9 @@
 namespace Tests\FFMpeg\Functional;
 
 use FFMpeg\FFMpeg;
+use PHPUnit\Framework\TestCase;
 
-abstract class FunctionalTestCase extends \PHPUnit_Framework_TestCase
+abstract class FunctionalTestCase extends TestCase
 {
     /**
      * @return FFMpeg

--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -4,8 +4,9 @@ namespace Tests\FFMpeg\Unit;
 
 use FFMpeg\FFMpegServiceProvider;
 use Silex\Application;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class FFMpegServiceProviderTest extends \PHPUnit_Framework_TestCase
+class FFMpegServiceProviderTest extends BaseTestCase
 {
     public function testWithConfig()
     {

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace Tests\FFMpeg\Unit;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
 {
     public function assertScalar($value)
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.