### PR TITLE
Use fluent interface when defining mocks

### DIFF
--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -105,7 +105,7 @@ class Video extends Audio
      * NOTE: This method is different to the Audio's one, because Video is using passes.
      * @inheritDoc
      */
-    public function getFinalCommand(FormatInterface $format, $outputPathfile) {
+    public function getFinalCommand(FormatInterface $format, string $outputPathfile) {
         $finalCommands = array();
 
         foreach($this->buildCommand($format, $outputPathfile) as $pass => $passCommands) {
@@ -123,7 +123,7 @@ class Video extends Audio
      * @inheritDoc
      * @return string[][]
      */
-    protected function buildCommand(FormatInterface $format, $outputPathfile) {
+    protected function buildCommand(FormatInterface $format, string $outputPathfile) {
         $commands = array('-y', '-i', $this->pathfile);
 
         $filters = clone $this->filters;

--- a/tests/Unit/Filters/Audio/AudioClipTest.php
+++ b/tests/Unit/Filters/Audio/AudioClipTest.php
@@ -18,7 +18,7 @@ class AudioClipTest extends TestCase {
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
         }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
 
         $filters = new AudioFilters($audio);
 
@@ -36,7 +36,7 @@ class AudioClipTest extends TestCase {
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
         }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
 
         $filters = new AudioFilters($audio);
 

--- a/tests/Unit/Filters/Audio/AudioMetadataTest.php
+++ b/tests/Unit/Filters/Audio/AudioMetadataTest.php
@@ -18,7 +18,7 @@ class AudioMetadataTest extends TestCase
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
             }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
 
         $filters = new AudioFilters($audio);
         $filters->addMetadata(array('title' => "Hello World"));
@@ -36,7 +36,7 @@ class AudioMetadataTest extends TestCase
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
             }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
 
         $filters = new AudioFilters($audio);
         $filters->addMetadata(array('genre' => 'Some Genre', 'artwork' => "/path/to/file.jpg"));
@@ -55,7 +55,7 @@ class AudioMetadataTest extends TestCase
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
             }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
 
         $filters = new AudioFilters($audio);
         $filters->addMetadata();

--- a/tests/Unit/Filters/Audio/AudioResamplableFilterTest.php
+++ b/tests/Unit/Filters/Audio/AudioResamplableFilterTest.php
@@ -16,7 +16,7 @@ class AudioResamplableFilterTest extends TestCase
     public function testApply()
     {
         $audio = $this->getAudioMock();
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
 
         $filter = new AudioResamplableFilter(500);
         $this->assertEquals(array('-ac', 2, '-ar', 500), $filter->apply($audio, $format));

--- a/tests/Unit/Filters/FiltersCollectionTest.php
+++ b/tests/Unit/Filters/FiltersCollectionTest.php
@@ -13,18 +13,18 @@ class FiltersCollectionTest extends TestCase
         $coll = new FiltersCollection();
         $this->assertCount(0, $coll);
 
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
+        $coll->add($this->getMockBuilder(\FFMpeg\Filters\FilterInterface::class)->getMock());
         $this->assertCount(1, $coll);
 
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
+        $coll->add($this->getMockBuilder(\FFMpeg\Filters\FilterInterface::class)->getMock());
         $this->assertCount(2, $coll);
     }
 
     public function testIterator()
     {
         $coll = new FiltersCollection();
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
+        $coll->add($this->getMockBuilder(\FFMpeg\Filters\FilterInterface::class)->getMock());
+        $coll->add($this->getMockBuilder(\FFMpeg\Filters\FilterInterface::class)->getMock());
 
         $this->assertInstanceOf('\ArrayIterator', $coll->getIterator());
         $this->assertCount(2, $coll->getIterator());
@@ -51,7 +51,7 @@ class FiltersCollectionTest extends TestCase
 
         $data = array();
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
 
         foreach ($coll as $filter) {
             $data = array_merge($data, $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/CropFilterTest.php
+++ b/tests/Unit/Filters/Video/CropFilterTest.php
@@ -22,7 +22,7 @@ class CropFilterTest extends TestCase
             ->method('getStreams')
             ->will($this->returnValue($streams));
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         $dimension = new Dimension(200, 150);
         $point = new Point(25, 35);

--- a/tests/Unit/Filters/Video/CustomFilterTest.php
+++ b/tests/Unit/Filters/Video/CustomFilterTest.php
@@ -12,7 +12,7 @@ class CustomFilterTest extends TestCase
     public function testApplyCustomFilter()
     {
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         $filter = new CustomFilter('whatever i put would end up as a filter');
         $this->assertEquals(array('-vf', 'whatever i put would end up as a filter'), $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -17,7 +17,7 @@ class ExtractMultipleFramesFilterTest extends TestCase
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getModulus')
             ->will($this->returnValue($modulus));

--- a/tests/Unit/Filters/Video/FrameRateFilterTest.php
+++ b/tests/Unit/Filters/Video/FrameRateFilterTest.php
@@ -14,7 +14,7 @@ class FrameRateFilterTest extends TestCase
         $gop = 42;
 
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('supportBFrames')
             ->will($this->returnValue(true));
@@ -31,7 +31,7 @@ class FrameRateFilterTest extends TestCase
         $gop = 42;
 
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('supportBFrames')
             ->will($this->returnValue(false));

--- a/tests/Unit/Filters/Video/PadFilterTest.php
+++ b/tests/Unit/Filters/Video/PadFilterTest.php
@@ -18,7 +18,7 @@ class PadFilterTest extends TestCase
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         $streams = new StreamCollection(array(
             new Stream(array(

--- a/tests/Unit/Filters/Video/ResizeFilterTest.php
+++ b/tests/Unit/Filters/Video/ResizeFilterTest.php
@@ -18,7 +18,7 @@ class ResizeFilterTest extends TestCase
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getModulus')
             ->will($this->returnValue($modulus));

--- a/tests/Unit/Filters/Video/RotateFilterTest.php
+++ b/tests/Unit/Filters/Video/RotateFilterTest.php
@@ -22,7 +22,7 @@ class RotateFilterTest extends TestCase
             ->method('getStreams')
             ->will($this->returnValue($streams));
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         $filter = new RotateFilter($value);
         $this->assertEquals(array('-vf', $value, '-metadata:s:v:0', 'rotate=0'), $filter->apply($video, $format));
@@ -48,7 +48,7 @@ class RotateFilterTest extends TestCase
         $video->expects($this->never())
             ->method('getStreams');
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         $filter = new RotateFilter($value);
         $this->assertEquals(array('-vf', $value, '-metadata:s:v:0', 'rotate=0'), $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/SynchronizeFilterTest.php
+++ b/tests/Unit/Filters/Video/SynchronizeFilterTest.php
@@ -10,7 +10,7 @@ class SynchronizeFilterTest extends TestCase
     public function testApply()
     {
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         $filter = new SynchronizeFilter();
         $this->assertEquals(array('-async', '1', '-metadata:s:v:0', 'start_time=0'), $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/WatermarkFilterTest.php
+++ b/tests/Unit/Filters/Video/WatermarkFilterTest.php
@@ -17,7 +17,7 @@ class WatermarkFilterTest extends TestCase
 
         $video = $this->getVideoMock();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         $filter = new WatermarkFilter(__DIR__ . '/../../../files/watermark.png');
         $this->assertEquals(array('-vf', 'movie='.__DIR__ .'/../../../files/watermark.png [watermark]; [in][watermark] overlay=0:0 [out]'), $filter->apply($video, $format));
@@ -30,7 +30,7 @@ class WatermarkFilterTest extends TestCase
     public function testDifferentCoordinaates()
     {
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
 
         // test position absolute
         $filter = new WatermarkFilter(__DIR__ . '/../../../files/watermark.png', array(

--- a/tests/Unit/Format/Audio/AudioTestCase.php
+++ b/tests/Unit/Format/Audio/AudioTestCase.php
@@ -101,7 +101,7 @@ abstract class AudioTestCase extends TestCase
 
     public function testCreateProgressListener()
     {
-        $media = $this->getMock('FFMpeg\Media\MediaTypeInterface');
+        $media = $this->getMockBuilder(\FFMpeg\Media\MediaTypeInterface::class)->getMock();
         $media->expects($this->any())
             ->method('getPathfile')
             ->will($this->returnValue(__FILE__));

--- a/tests/Unit/Format/Video/VideoTestCase.php
+++ b/tests/Unit/Format/Video/VideoTestCase.php
@@ -54,7 +54,7 @@ abstract class VideoTestCase extends AudioTestCase
 
     public function testCreateProgressListener()
     {
-        $media = $this->getMock('FFMpeg\Media\MediaTypeInterface');
+        $media = $this->getMockBuilder(\FFMpeg\Media\MediaTypeInterface::class)->getMock();
         $media->expects($this->any())
             ->method('getPathfile')
             ->will($this->returnValue(__FILE__));

--- a/tests/Unit/Media/AudioTest.php
+++ b/tests/Unit/Media/AudioTest.php
@@ -29,7 +29,7 @@ class AudioTest extends AbstractStreamableTestCase
         $audio = new Audio(__FILE__, $driver, $ffprobe);
         $audio->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Audio\AudioFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Audio\AudioFilterInterface::class)->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -50,7 +50,7 @@ class AudioTest extends AbstractStreamableTestCase
         $audio = new Audio(__FILE__, $driver, $ffprobe);
         $audio->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Video\VideoFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Video\VideoFilterInterface::class)->getMock();
 
         $filters->expects($this->never())
             ->method('add');
@@ -65,12 +65,12 @@ class AudioTest extends AbstractStreamableTestCase
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
 
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -91,12 +91,12 @@ class AudioTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -104,7 +104,7 @@ class AudioTest extends AbstractStreamableTestCase
 
         $audio = new Audio(__FILE__, $driver, $ffprobe);
 
-        $filter = $this->getMock('FFMpeg\Filters\Audio\AudioFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Audio\AudioFilterInterface::class)->getMock();
         $filter->expects($this->once())
             ->method('apply')
             ->with($audio, $format)
@@ -138,7 +138,7 @@ class AudioTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -180,7 +180,7 @@ class AudioTest extends AbstractStreamableTestCase
 
     public function provideSaveData()
     {
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -191,7 +191,7 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getAudioChannels')
             ->will($this->returnValue(5));
 
-        $audioFormat = $this->getMock('FFMpeg\Format\AudioInterface');
+        $audioFormat = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
         $audioFormat->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -205,7 +205,7 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getAudioCodec')
             ->will($this->returnValue('patati-patata-audio'));
 
-        $formatExtra = $this->getMock('FFMpeg\Format\AudioInterface');
+        $formatExtra = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
         $formatExtra->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('extra', 'param')));
@@ -216,7 +216,7 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getAudioChannels')
             ->will($this->returnValue(5));
 
-        $listeners = array($this->getMock('Alchemy\BinaryDriver\Listeners\ListenerInterface'));
+        $listeners = array($this->getMockBuilder(\Alchemy\BinaryDriver\Listeners\ListenerInterface::class)->getMock());
 
         $progressableFormat = $this->getMockBuilder('Tests\FFMpeg\Unit\Media\AudioProg')
             ->disableOriginalConstructor()->getMock();
@@ -290,7 +290,7 @@ class AudioTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -317,7 +317,7 @@ class AudioTest extends AbstractStreamableTestCase
 
         $outputPathfile = '/target/file';
 
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('param')));

--- a/tests/Unit/Media/ConcatTest.php
+++ b/tests/Unit/Media/ConcatTest.php
@@ -34,7 +34,7 @@ class ConcatTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Concat\ConcatFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Concat\ConcatFilterInterface::class)->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -115,7 +115,7 @@ class ConcatTest extends AbstractMediaTestCase
 
         array_push($commands, $pathfile);
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -136,9 +136,9 @@ class ConcatTest extends AbstractMediaTestCase
                 array(
                     '-i', __FILE__,
                     '-i', 'concat-2.mp4',
-                    '-filter_complex', 
+                    '-filter_complex',
                     '[0:v:0] [0:a:0] [1:v:0] [1:a:0] concat=n=2:v=1:a=1 [v] [a]',
-                    '-map', '[v]', 
+                    '-map', '[v]',
                     '-map', '[a]'
                 ),
             ),

--- a/tests/Unit/Media/FrameTest.php
+++ b/tests/Unit/Media/FrameTest.php
@@ -36,7 +36,7 @@ class FrameTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Frame\FrameFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Frame\FrameFilterInterface::class)->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -76,7 +76,7 @@ class FrameTest extends AbstractMediaTestCase
             $frame->save($pathfile, $accurate, $base64);
         }
     }
-    
+
     public function provideSaveOptions()
     {
         return array(

--- a/tests/Unit/Media/GifTest.php
+++ b/tests/Unit/Media/GifTest.php
@@ -51,7 +51,7 @@ class GifTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Gif\GifFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Gif\GifFilterInterface::class)->getMock();
 
         $filters->expects($this->once())
             ->method('add')

--- a/tests/Unit/Media/VideoTest.php
+++ b/tests/Unit/Media/VideoTest.php
@@ -29,7 +29,7 @@ class VideoTest extends AbstractStreamableTestCase
         $video = new Video(__FILE__, $driver, $ffprobe);
         $video->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Video\VideoFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Video\VideoFilterInterface::class)->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -50,7 +50,7 @@ class VideoTest extends AbstractStreamableTestCase
         $video = new Video(__FILE__, $driver, $ffprobe);
         $video->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Audio\AudioFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Audio\AudioFilterInterface::class)->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -79,7 +79,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getPasses')
             ->will($this->returnValue(1));
@@ -87,7 +87,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -108,7 +108,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -116,7 +116,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getPasses')
             ->will($this->returnValue(2));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -124,7 +124,7 @@ class VideoTest extends AbstractStreamableTestCase
 
         $video = new Video(__FILE__, $driver, $ffprobe);
 
-        $filter = $this->getMock('FFMpeg\Filters\Video\VideoFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Video\VideoFilterInterface::class)->getMock();
         $filter->expects($this->once())
             ->method('apply')
             ->with($video, $format)
@@ -158,7 +158,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -233,7 +233,7 @@ class VideoTest extends AbstractStreamableTestCase
 
     public function provideSaveData()
     {
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -253,7 +253,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array('foo', 'bar')));
 
-        $format2 = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format2 = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format2->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -273,7 +273,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array('foo', 'bar')));
 
-        $audioFormat = $this->getMock('FFMpeg\Format\AudioInterface');
+        $audioFormat = $this->getMockBuilder(\FFMpeg\Format\AudioInterface::class)->getMock();
         $audioFormat->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -290,7 +290,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getPasses')
             ->will($this->returnValue(1));
 
-        $audioVideoFormat = $this->getMock('FFMpeg\Format\VideoInterface');
+        $audioVideoFormat = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $audioVideoFormat->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -316,7 +316,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $audioVideoFormatSinglePass = $this->getMock('FFMpeg\Format\VideoInterface');
+        $audioVideoFormatSinglePass = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $audioVideoFormatSinglePass->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -342,7 +342,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $formatExtra = $this->getMock('FFMpeg\Format\VideoInterface');
+        $formatExtra = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $formatExtra->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('extra', 'param')));
@@ -362,7 +362,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $formatExtra2 = $this->getMock('FFMpeg\Format\VideoInterface');
+        $formatExtra2 = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $formatExtra2->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('extra', 'param')));
@@ -382,7 +382,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $listeners = array($this->getMock('Alchemy\BinaryDriver\Listeners\ListenerInterface'));
+        $listeners = array($this->getMockBuilder(\Alchemy\BinaryDriver\Listeners\ListenerInterface::class)->getMock());
 
         $progressableFormat = $this->getMockBuilder('Tests\FFMpeg\Unit\Media\Prog')
             ->disableOriginalConstructor()->getMock();
@@ -585,7 +585,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -612,7 +612,7 @@ class VideoTest extends AbstractStreamableTestCase
 
         $outputPathfile = '/target/file';
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder(\FFMpeg\Format\VideoInterface::class)->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('param')));

--- a/tests/Unit/Media/WaveformTest.php
+++ b/tests/Unit/Media/WaveformTest.php
@@ -25,7 +25,7 @@ class WaveformTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Waveform\WaveformFilterInterface');
+        $filter = $this->getMockBuilder(\FFMpeg\Filters\Waveform\WaveformFilterInterface::class)->getMock();
 
         $filters->expects($this->once())
             ->method('add')

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -11,11 +11,11 @@ class TestCase extends PhpUnitTestCase {
     }
 
     public function getLoggerMock() {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->getMockBuilder(\Psr\Log\LoggerInterface::class)->getMock();
     }
 
     public function getCacheMock() {
-        return $this->getMock('Doctrine\Common\Cache\Cache');
+        return $this->getMockBuilder(\Doctrine\Common\Cache\Cache::class)->getMock();
     }
 
     public function getTimeCodeMock() {
@@ -73,15 +73,15 @@ class TestCase extends PhpUnitTestCase {
     }
 
     public function getFFProbeParserMock() {
-        return $this->getMock('FFMpeg\FFProbe\OutputParserInterface');
+        return $this->getMockBuilder(\FFMpeg\FFProbe\OutputParserInterface::class)->getMock();
     }
 
     public function getFFProbeOptionsTesterMock() {
-        return $this->getMock('FFMpeg\FFProbe\OptionsTesterInterface');
+        return $this->getMockBuilder(\FFMpeg\FFProbe\OptionsTesterInterface::class)->getMock();
     }
 
     public function getFFProbeMapperMock() {
-        return $this->getMock('FFMpeg\FFProbe\MapperInterface');
+        return $this->getMockBuilder(\FFMpeg\FFProbe\MapperInterface::class)->getMock();
     }
 
     public function getFFProbeOptionsTesterMockWithOptions(array $options) {
@@ -97,7 +97,7 @@ class TestCase extends PhpUnitTestCase {
     }
 
     public function getConfigurationMock() {
-        return $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        return $this->getMockBuilder(\Alchemy\BinaryDriver\ConfigurationInterface::class)->getMock();
     }
 
     public function getFormatMock() {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | Yes
| New feature?       | no
| BC breaks?         | Yes
| Deprecations?      | Yes
| Fixed tickets      | #412 
| Related issues/PRs | #412 #455 
| License            | MIT

As suggested in #455, let's fix the tests step by step. First:
- Use a fluent interface when defining `Mocks`. This fix tests `Call to undefined method getMock()`.