### PR TITLE
Fix Expect Exception tests

### DIFF
--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -50,7 +50,8 @@ class FFMpegServiceProviderTest extends TestCase
             )
         ));
 
-        $this->setExpectedException('FFMpeg\Exception\ExecutableNotFoundException', 'Unable to load FFMpeg');
+        $this->expectException(\FFMpeg\Exception\ExecutableNotFoundException::class);
+        $this->expectExceptionMessage('Unable to load FFMpeg');
         $app['ffmpeg'];
     }
 
@@ -63,7 +64,8 @@ class FFMpegServiceProviderTest extends TestCase
             )
         ));
 
-        $this->setExpectedException('FFMpeg\Exception\ExecutableNotFoundException', 'Unable to load FFProbe');
+        $this->expectException(\FFMpeg\Exception\ExecutableNotFoundException::class);
+        $this->expectExceptionMessage('Unable to load FFProbe');
         $app['ffmpeg.ffprobe'];
     }
 }

--- a/tests/Unit/Media/AudioTest.php
+++ b/tests/Unit/Media/AudioTest.php
@@ -55,7 +55,7 @@ class AudioTest extends AbstractStreamableTestCase
         $filters->expects($this->never())
             ->method('add');
 
-        $this->setExpectedException('FFMpeg\Exception\InvalidArgumentException');
+        $this->expectException(\FFMpeg\Exception\InvalidArgumentException::class);
         $audio->addFilter($filter);
     }
 
@@ -82,7 +82,7 @@ class AudioTest extends AbstractStreamableTestCase
             ->will($this->throwException($failure));
 
         $audio = new Audio(__FILE__, $driver, $ffprobe);
-        $this->setExpectedException('FFMpeg\Exception\RuntimeException');
+        $this->expectException(\FFMpeg\Exception\RuntimeException::class);
         $audio->save($format, $outputPathfile);
     }
 

--- a/tests/Unit/Media/VideoTest.php
+++ b/tests/Unit/Media/VideoTest.php
@@ -99,7 +99,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->will($this->throwException($failure));
 
         $video = new Video(__FILE__, $driver, $ffprobe);
-        $this->setExpectedException('FFMpeg\Exception\RuntimeException');
+        $this->expectException(\FFMpeg\Exception\RuntimeException::class);
         $video->save($format, $outputPathfile);
     }
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | Yes
| New feature?       | no
| BC breaks?         | Yes
| Deprecations?      | Yes
| Fixed tickets      | #412 
| Related issues/PRs | #412 #455 #458 
| License            | MIT

As suggested in #455, let's fix the tests step by step. Second:
- Use `expectException` and `expectExceptionMessage` instead of `setExpectedException`, as it doesn't exist in `PHPUnit 6` anymore.