### PR TITLE
use official version of neutron/temporary-filesystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": "^7.1",
         "alchemy/binary-driver": "^1.6",
         "evenement/evenement": "^2.0 || ^1.0",
-        "neutron/temporary-filesystem": "dev-jens1o-update-deps",
+        "neutron/temporary-filesystem": "^2.3",
         "sabre/cache": "^1.0"
     },
     "suggest": {
@@ -48,12 +48,6 @@
         "phpunit/phpunit": "^6.4",
         "squizlabs/php_codesniffer": "^3.2"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/jens1o/Temporary-Filesystem"
-        }
-    ],
     "autoload": {
         "psr-0": {
             "FFMpeg\\": "src"


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | -
| Related issues/PRs | #470
| License            | MIT

#### What's in this PR?

use official version of *neutron/temporary-filesystem* in `composer.json`

#### Why?

the dependency problems have been resolved in [version 2.3.0](https://github.com/romainneutron/Temporary-Filesystem/commits/2.3.0).