### PR TITLE
Fix Clipping video transcoding progress not correct

### DIFF
--- a/src/FFMpeg/Format/Audio/DefaultAudio.php
+++ b/src/FFMpeg/Format/Audio/DefaultAudio.php
@@ -121,7 +121,7 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     /**
      * {@inheritdoc}
      */
-    public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total)
+    public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total, $duration = 0)
     {
         $format = $this;
         $listener = new AudioProgressListener($ffprobe, $media->getPathfile(), $pass, $total);

--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -255,9 +255,8 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
             return;
         }
 
-        $this->totalSize = $format->get('size') / 1024;
-        $this->duration = (int) $this->duration > 0 ? (int) $this->duration : $format->get('duration');
-
+        $this->duration = (int) $this->duration > 0 ? $this->duration : $format->get('duration');
+        $this->totalSize = $format->get('size') / 1024 * ($this->duration / $format->get('duration'));
         $this->initialized = true;
     }
 }

--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -80,12 +80,13 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
      *
      * @throws RuntimeException
      */
-    public function __construct(FFProbe $ffprobe, $pathfile, $currentPass, $totalPass)
+    public function __construct(FFProbe $ffprobe, $pathfile, $currentPass, $totalPass, $duration = 0)
     {
         $this->ffprobe = $ffprobe;
         $this->pathfile = $pathfile;
         $this->currentPass = $currentPass;
         $this->totalPass = $totalPass;
+        $this->duration = $duration;
     }
 
     /**
@@ -255,7 +256,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
         }
 
         $this->totalSize = $format->get('size') / 1024;
-        $this->duration = $format->get('duration');
+        $this->duration = (int) $this->duration > 0 ? (int) $this->duration : $format->get('duration');
 
         $this->initialized = true;
     }

--- a/src/FFMpeg/Format/ProgressableInterface.php
+++ b/src/FFMpeg/Format/ProgressableInterface.php
@@ -24,8 +24,9 @@ interface ProgressableInterface extends EventEmitterInterface
      * @param FFProbe            $ffprobe
      * @param Integer            $pass    The current pas snumber
      * @param Integer            $total   The total pass number
+     * @param Integer            $duration   The new video duration
      *
      * @return array An array of listeners
      */
-    public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total);
+    public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total, $duration = 0);
 }

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -125,7 +125,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     /**
      * {@inheritdoc}
      */
-    public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total)
+    public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total, $duration = 0)
     {
         $format = $this;
         $listeners = array(new VideoProgressListener($ffprobe, $media->getPathfile(), $pass, $total));

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -62,7 +62,7 @@ class Audio extends AbstractStreamableMedia
         $listeners = null;
 
         if ($format instanceof ProgressableInterface) {
-            $listeners = $format->createProgressListener($this, $this->ffprobe, 1, 1);
+            $listeners = $format->createProgressListener($this, $this->ffprobe, 1, 1, 0);
         }
 
         $commands = $this->buildCommand($format, $outputPathfile);

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -24,6 +24,7 @@ use FFMpeg\Format\ProgressableInterface;
 use FFMpeg\Format\AudioInterface;
 use FFMpeg\Format\VideoInterface;
 use Neutron\TemporaryFilesystem\Manager as FsManager;
+use FFMpeg\Filters\Video\ClipFilter;
 
 class Video extends Audio
 {
@@ -78,9 +79,23 @@ class Video extends Audio
             try {
                 /** add listeners here */
                 $listeners = null;
-
+        
                 if ($format instanceof ProgressableInterface) {
-                    $listeners = $format->createProgressListener($this, $this->ffprobe, $pass + 1, $totalPasses);
+                    $filters = clone $this->filters;
+                    $duration = 0;
+                    /*
+                     check the filters of the video, 
+                        and if the video has the ClipFilter than: 
+                            take the new video duration and send to the
+                            FFMpeg\Format\ProgressListener\AbstractProgressListener class
+                     */
+                    foreach ($filters as $filter) {
+                        if($filter instanceof ClipFilter){
+                            $duration = $filter->getDuration()->toSeconds();
+                            break;
+                        }
+                    }
+                    $listeners = $format->createProgressListener($this, $this->ffprobe, $pass + 1, $totalPasses, $duration);
                 }
 
                 $this->driver->command($passCommands, false, $listeners);

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -83,12 +83,10 @@ class Video extends Audio
                 if ($format instanceof ProgressableInterface) {
                     $filters = clone $this->filters;
                     $duration = 0;
-                    /*
-                     check the filters of the video, 
-                        and if the video has the ClipFilter than: 
-                            take the new video duration and send to the
-                            FFMpeg\Format\ProgressListener\AbstractProgressListener class
-                     */
+                    
+                    // check the filters of the video, and if the video has the ClipFilter then
+                    // take the new video duration and send to the
+                    // FFMpeg\Format\ProgressListener\AbstractProgressListener class
                     foreach ($filters as $filter) {
                         if($filter instanceof ClipFilter){
                             $duration = $filter->getDuration()->toSeconds();

--- a/tests/Unit/Format/ProgressListener/VideoProgressListenerTest.php
+++ b/tests/Unit/Format/ProgressListener/VideoProgressListenerTest.php
@@ -11,7 +11,7 @@ class VideoProgressListenerTest extends TestCase
     /**
      * @dataProvider provideData
      */
-    public function testHandle($size, $duration,
+    public function testHandle($size, $duration, $newVideoDuration,
         $data, $expectedPercent, $expectedRemaining, $expectedRate,
         $data2, $expectedPercent2, $expectedRemaining2, $expectedRate2,
         $currentPass, $totalPass
@@ -26,7 +26,7 @@ class VideoProgressListenerTest extends TestCase
                 'duration' => $duration,
             ))));
 
-        $listener = new VideoProgressListener($ffprobe, __FILE__, $currentPass, $totalPass);
+        $listener = new VideoProgressListener($ffprobe, __FILE__, $currentPass, $totalPass, $newVideoDuration);
         $phpunit = $this;
         $n = 0;
         $listener->on('progress', function ($percent, $remaining, $rate) use (&$n, $phpunit, $expectedPercent, $expectedRemaining, $expectedRate, $expectedPercent2, $expectedRemaining2, $expectedRate2) {
@@ -57,6 +57,7 @@ class VideoProgressListenerTest extends TestCase
             array(
                 147073958,
                 281.147533,
+                281.147533,
                 'frame=  206 fps=202 q=10.0 size=     571kB time=00:00:07.12 bitrate= 656.8kbits/s dup=9 drop=0',
                 2,
                 0,
@@ -71,6 +72,7 @@ class VideoProgressListenerTest extends TestCase
             array(
                 147073958,
                 281.147533,
+                281.147533,
                 'frame=  206 fps=202 q=10.0 size=     571kB time=00:00:07.12 bitrate= 656.8kbits/s dup=9 drop=0',
                 1,
                 0,
@@ -80,6 +82,21 @@ class VideoProgressListenerTest extends TestCase
                 32,
                 3868,
                 1,
+                2
+            ),
+            array(
+                147073958,
+                281.147533,
+                35,
+                'frame=  206 fps=202 q=10.0 size=     571kB time=00:00:07.12 bitrate= 656.8kbits/s dup=9 drop=0',
+                60,
+                0,
+                0,
+                'frame=  854 fps=113 q=20.0 size=    4430kB time=00:00:33.04 bitrate=1098.5kbits/s dup=36 drop=0',
+                97,
+                0,
+                3868,
+                2,
                 2
             )
         );


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | Yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### The progress on the clipping video is not correct!

When you clipping video, the progress showing wrong info. Showing the info like you transcoding the source video instead of clipping video part you trying to  transcode.

#### Why?

On the class [AbstractProgressListener](https://github.com/PHP-FFMpeg/PHP-FFMpeg/blob/master/src/FFMpeg/Format/ProgressListner/AbstractProgressListener.php) **initialize** function (line 258), the duration for compaction  is getting from the source video instead of the clipping video.

#### Example Usage

```php
require_once( dirname(__DIR__) . "/vendor/autoload.php");

$ffmpeg = FFMpeg\FFMpeg::create();

$saveTo = __DIR__ . "/5_to_15_oceans.mp4";

$video = $ffmpeg->open("http://vjs.zencdn.net/v/oceans.mp4");

$video
    ->filters()
    ->clip(
        \FFMpeg\Coordinate\TimeCode::fromSeconds(5), 
        \FFMpeg\Coordinate\TimeCode::fromSeconds(10)
    );

$format = new \FFMpeg\Format\Video\X264('aac');

$format->on('progress', function ($video, $format, $percentage) {
    echo "$percentage % transcoded \n";
});

$format
    ->setKiloBitrate(1000)
    ->setAudioChannels(2)
    ->setAudioKiloBitrate(256);

$video->save($format, $saveTo); 
```


### Before the Fix output of the code above:
###### 0 % transcoded
###### 0 % transcoded
###### 1 % transcoded
###### 2 % transcoded
###### 3 % transcoded
###### 5 % transcoded
###### 6 % transcoded
###### 6 % transcoded
###### 7 % transcoded
###### 7 % transcoded
###### 7 % transcoded
###### 8 % transcoded
###### 8 % transcoded
###### 8 % transcoded
###### 8 % transcoded
###### 9 % transcoded
###### 9 % transcoded
###### 9 % transcoded
###### 10 % transcoded
###### 10 % transcoded
###### 10 % transcoded
###### 50 % transcoded
###### 50 % transcoded
###### 51 % transcoded
###### 52 % transcoded
###### 53 % transcoded
###### 55 % transcoded
###### 56 % transcoded
###### 56 % transcoded
###### 57 % transcoded
###### 57 % transcoded
###### 57 % transcoded
###### 58 % transcoded
###### 58 % transcoded
###### 58 % transcoded
###### 58 % transcoded
###### 59 % transcoded
###### 59 % transcoded
###### 60 % transcoded
###### 60 % transcoded
###### 60 % transcoded
###### 60 % transcoded


### After the Fix output of the code above:
###### 0 % transcoded 
###### 0 % transcoded 
###### 0 % transcoded 
###### 1 % transcoded 
###### 4 % transcoded 
###### 6 % transcoded 
###### 9 % transcoded 
###### 11 % transcoded 
###### 11 % transcoded 
###### 14 % transcoded 
###### 23 % transcoded 
###### 27 % transcoded 
###### 30 % transcoded 
###### 30 % transcoded 
###### 32 % transcoded 
###### 32 % transcoded 
###### 34 % transcoded 
###### 34 % transcoded 
###### 37 % transcoded 
###### 37 % transcoded 
###### 37 % transcoded 
###### 39 % transcoded 
###### 39 % transcoded 
###### 41 % transcoded 
###### 41 % transcoded 
###### 43 % transcoded 
###### 46 % transcoded 
###### 48 % transcoded 
###### 48 % transcoded 
###### 49 % transcoded 
###### 50 % transcoded 
###### 50 % transcoded 
###### 51 % transcoded 
###### 56 % transcoded 
###### 61 % transcoded 
###### 64 % transcoded 
###### 73 % transcoded 
###### 77 % transcoded 
###### 80 % transcoded 
###### 82 % transcoded 
###### 84 % transcoded 
###### 87 % transcoded 
###### 87 % transcoded 
###### 89 % transcoded 
###### 89 % transcoded 
###### 91 % transcoded 
###### 93 % transcoded 
###### 93 % transcoded 
###### 96 % transcoded 
###### 98 % transcoded 
###### 99 % transcoded 
###### 100 % transcoded