### PR TITLE
Fix Clipping video transcoding progress not correct #2

### DIFF
--- a/src/FFMpeg/Format/Audio/DefaultAudio.php
+++ b/src/FFMpeg/Format/Audio/DefaultAudio.php
@@ -124,7 +124,7 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total, $duration = 0)
     {
         $format = $this;
-        $listener = new AudioProgressListener($ffprobe, $media->getPathfile(), $pass, $total);
+        $listener = new AudioProgressListener($ffprobe, $media->getPathfile(), $pass, $total, $duration);
         $listener->on('progress', function () use ($media, $format) {
            $format->emit('progress', array_merge(array($media, $format), func_get_args()));
         });

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -128,7 +128,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total, $duration = 0)
     {
         $format = $this;
-        $listeners = array(new VideoProgressListener($ffprobe, $media->getPathfile(), $pass, $total));
+        $listeners = array(new VideoProgressListener($ffprobe, $media->getPathfile(), $pass, $total, $duration));
 
         foreach ($listeners as $listener) {
             $listener->on('progress', function () use ($format, $media) {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #484 
| Related issues/PRs | #484 
| License            | MIT

#### This is the final fix for the Fix Clipping video transcoding progress not correct

I forgot to change the Default Media classes the createProgressListener function.

