### PR TITLE
allow to set frame file type instead of hardcoded jpg

### DIFF
--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -35,6 +35,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     private $priority;
     private $frameRate;
     private $destinationFolder;
+    private $frameFileType = 'jpg';
 
     public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $destinationFolder = __DIR__, $priority = 0)
     {
@@ -47,6 +48,10 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
 
         // Set the destination folder
         $this->destinationFolder = $destinationFolder;
+    }
+
+    public function setFrameFileType($frameFileType) {
+    	$this->frameFileType = $frameFileType;
     }
 
     /**
@@ -117,7 +122,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
             // Set the parameters
             $commands[] = '-vf';
             $commands[] = 'fps=' . $this->frameRate;
-            $commands[] = $this->destinationFolder . 'frame-%'.$nbDigitsInFileNames.'d.jpg';
+            $commands[] = $this->destinationFolder . 'frame-%'.$nbDigitsInFileNames.'d.' . $this->frameFileType;
         }
         catch (RuntimeException $e) {
             throw new RuntimeException('An error occured while extracting the frames: ' . $e->getMessage() . '. The code: ' . $e->getCode());

--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -37,6 +37,9 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     private $destinationFolder;
     private $frameFileType = 'jpg';
 
+    /** @var array */
+    private static $supportedFrameFileTypes = ['jpg', 'jpeg', 'png'];
+
     public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $destinationFolder = __DIR__, $priority = 0)
     {
         $this->priority = $priority;
@@ -52,9 +55,16 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
 
 	/**
 	 * @param string $frameFileType
+	 * @throws \FFMpeg\Exception\InvalidArgumentException
+	 * @return ExtractMultipleFramesFilter
 	 */
     public function setFrameFileType($frameFileType) {
-    	$this->frameFileType = $frameFileType;
+    	if (in_array($frameFileType, self::$supportedFrameFileTypes)) {
+    		$this->frameFileType = $frameFileType;
+    		return $this;
+    	}
+
+    	throw new InvalidArgumentException('Invalid frame file type, use: ' . implode(',', self::$supportedFrameFileTypes));
     }
 
     /**

--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -50,6 +50,9 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
         $this->destinationFolder = $destinationFolder;
     }
 
+	/**
+	 * @param string $frameFileType
+	 */
     public function setFrameFileType($frameFileType) {
     	$this->frameFileType = $frameFileType;
     }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -46,6 +46,12 @@ class ExtractMultipleFramesFilterTest extends TestCase
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'png', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'png', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'png', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'png', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'png', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.png')),
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
         );
     }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -12,7 +12,7 @@ class ExtractMultipleFramesFilterTest extends TestCase
     /**
      * @dataProvider provideFrameRates
      */
-    public function testApply($frameRate, $destinationFolder, $duration, $modulus, $expected)
+    public function testApply($frameRate, $frameFileType,$destinationFolder, $duration, $modulus, $expected)
     {
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
@@ -34,18 +34,19 @@ class ExtractMultipleFramesFilterTest extends TestCase
             ->will($this->returnValue($streams));
 
         $filter = new ExtractMultipleFramesFilter($frameRate, $destinationFolder);
+        $filter->setFrameFileType($frameFileType);
         $this->assertEquals($expected, $filter->apply($video, $format));
     }
 
     public function provideFrameRates()
     {
         return array(
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
         );
     }
 }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -68,7 +68,7 @@ class ExtractMultipleFramesFilterTest extends TestCase
      * @expectedException \FFMpeg\Exception\InvalidArgumentException
      */
     public function testInvalidFrameFileType() {
-    	$filter = new ExtractMultipleFramesFilter('1/1', '/');
+        $filter = new ExtractMultipleFramesFilter('1/1', '/');
         $filter->setFrameFileType('webm');
     }
 }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -41,18 +41,34 @@ class ExtractMultipleFramesFilterTest extends TestCase
     public function provideFrameRates()
     {
         return array(
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'png', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'png', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'png', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'png', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'png', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
+
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpeg')),
+
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
         );
+    }
+
+    /**
+     * @expectedException \FFMpeg\Exception\InvalidArgumentException
+     */
+    public function testInvalidFrameFileType() {
+    	$filter = new ExtractMultipleFramesFilter('1/1', '/');
+        $filter->setFrameFileType('webm');
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes # 
| Related issues/PRs | #493 
| License            | MIT

#### What's in this PR?

Explain the contents of the PR.

When using ExtractMultipleFramesFilter, it would be nice to choose the file type of the frame image e.g jpg, png, etc.. 

#### Why?

Which problem does the PR fix?

It might be better to create frames with png than with jpg: 
https://twitter.com/FFmpeg/status/970382979280154624

#### Example Usage

```php
$frameFileType = 'jpg';
$filter = new ExtractMultipleFramesFilter($frameRate, $destinationFolder);
$filter->setFrameFileType($frameFileType);
```