### PR TITLE
Issue#494

### DIFF
--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -35,6 +35,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     private $priority;
     private $frameRate;
     private $destinationFolder;
+    private $frameFileType = 'jpg';
 
     public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $destinationFolder = __DIR__, $priority = 0)
     {
@@ -47,6 +48,10 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
 
         // Set the destination folder
         $this->destinationFolder = $destinationFolder;
+    }
+
+    public function setFrameFileType($frameFileType) {
+    	$this->frameFileType = $frameFileType;
     }
 
     /**
@@ -117,7 +122,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
             // Set the parameters
             $commands[] = '-vf';
             $commands[] = 'fps=' . $this->frameRate;
-            $commands[] = $this->destinationFolder . 'frame-%'.$nbDigitsInFileNames.'d.jpg';
+            $commands[] = $this->destinationFolder . 'frame-%'.$nbDigitsInFileNames.'d.' . $this->frameFileType;
         }
         catch (RuntimeException $e) {
             throw new RuntimeException('An error occured while extracting the frames: ' . $e->getMessage() . '. The code: ' . $e->getCode());

--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -37,6 +37,9 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     private $destinationFolder;
     private $frameFileType = 'jpg';
 
+    /** @var array */
+    private static $supportedFrameFileTypes = ['jpg', 'jpeg', 'png'];
+
     public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $destinationFolder = __DIR__, $priority = 0)
     {
         $this->priority = $priority;
@@ -52,9 +55,16 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
 
 	/**
 	 * @param string $frameFileType
+	 * @throws \FFMpeg\Exception\InvalidArgumentException
+	 * @return ExtractMultipleFramesFilter
 	 */
     public function setFrameFileType($frameFileType) {
-    	$this->frameFileType = $frameFileType;
+    	if (in_array($frameFileType, self::$supportedFrameFileTypes)) {
+    		$this->frameFileType = $frameFileType;
+    		return $this;
+    	}
+
+    	throw new InvalidArgumentException('Invalid frame file type, use: ' . implode(',', self::$supportedFrameFileTypes));
     }
 
     /**

--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -50,6 +50,9 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
         $this->destinationFolder = $destinationFolder;
     }
 
+	/**
+	 * @param string $frameFileType
+	 */
     public function setFrameFileType($frameFileType) {
     	$this->frameFileType = $frameFileType;
     }

--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -16,8 +16,7 @@ use FFMpeg\Exception\RuntimeException;
 use FFMpeg\Media\Video;
 use FFMpeg\Format\VideoInterface;
 
-class ExtractMultipleFramesFilter implements VideoFilterInterface
-{
+class ExtractMultipleFramesFilter implements VideoFilterInterface {
     /** will extract a frame every second */
     const FRAMERATE_EVERY_SEC = '1/1';
     /** will extract a frame every 2 seconds */
@@ -31,116 +30,39 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     /** will extract a frame every minute */
     const FRAMERATE_EVERY_60SEC = '1/60';
 
-    /** @var integer */
-    private $priority;
+    /**
+     * @var string
+     */
     private $frameRate;
-    private $destinationFolder;
-    private $frameFileType = 'jpg';
 
-    /** @var array */
-    private static $supportedFrameFileTypes = ['jpg', 'jpeg', 'png'];
+    /**
+     * @var int
+     */
+    private $priority;
 
-    public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $destinationFolder = __DIR__, $priority = 0)
-    {
-        $this->priority = $priority;
+    /**
+     * @param $frameRate
+     * @param selfFRAMERATE_EVERY_SEC $frameFileType
+     */
+    public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $priority = 0) {
         $this->frameRate = $frameRate;
-
-        // Make sure that the destination folder has a trailing slash
-        if(strcmp( substr($destinationFolder, -1), "/") != 0)
-            $destinationFolder .= "/";
-
-        // Set the destination folder
-        $this->destinationFolder = $destinationFolder;
-    }
-
-	/**
-	 * @param string $frameFileType
-	 * @throws \FFMpeg\Exception\InvalidArgumentException
-	 * @return ExtractMultipleFramesFilter
-	 */
-    public function setFrameFileType($frameFileType) {
-    	if (in_array($frameFileType, self::$supportedFrameFileTypes)) {
-    		$this->frameFileType = $frameFileType;
-    		return $this;
-    	}
-
-    	throw new InvalidArgumentException('Invalid frame file type, use: ' . implode(',', self::$supportedFrameFileTypes));
+        $this->priority = $priority;
     }
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
-    public function getPriority()
-    {
+    public function getPriority() {
         return $this->priority;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getFrameRate()
-    {
-        return $this->frameRate;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDestinationFolder()
-    {
-        return $this->destinationFolder;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function apply(Video $video, VideoInterface $format)
-    {
-        $commands = array();
-        $duration = 0;
-
-        try {
-            // Get the duration of the video
-            foreach ($video->getStreams()->videos() as $stream) {
-                if ($stream->has('duration')) {
-                    $duration = $stream->get('duration');
-                }
-            }
-
-            // Get the number of frames per second we have to extract.
-            if(preg_match('/(\d+)(?:\s*)([\+\-\*\/])(?:\s*)(\d+)/', $this->frameRate, $matches) !== FALSE){
-                $operator = $matches[2];
-
-                switch($operator){
-                    case '/':
-                        $nbFramesPerSecond = $matches[1] / $matches[3];
-                        break;
-
-                    default:
-                        throw new InvalidArgumentException('The frame rate is not a proper division: ' . $this->frameRate);
-                        break;
-                }
-            }
-
-            // Set the number of digits to use in the exported filenames
-            $nbImages = ceil( $duration * $nbFramesPerSecond );
-
-            if($nbImages < 100)
-                $nbDigitsInFileNames = "02";
-            elseif($nbImages < 1000)
-                $nbDigitsInFileNames = "03";
-            else
-                $nbDigitsInFileNames = "06";
-
-            // Set the parameters
-            $commands[] = '-vf';
-            $commands[] = 'fps=' . $this->frameRate;
-            $commands[] = $this->destinationFolder . 'frame-%'.$nbDigitsInFileNames.'d.' . $this->frameFileType;
-        }
-        catch (RuntimeException $e) {
-            throw new RuntimeException('An error occured while extracting the frames: ' . $e->getMessage() . '. The code: ' . $e->getCode());
-        }
-
+    public function apply(Video $video, VideoInterface $format) {
+        $commands = [];
+        $commands[] = '-vf';
+        $commands[] = 'fps=' . $this->frameRate;
         return $commands;
     }
 }

--- a/src/FFMpeg/Filters/Video/VideoFilters.php
+++ b/src/FFMpeg/Filters/Video/VideoFilters.php
@@ -65,9 +65,9 @@ class VideoFilters extends AudioFilters
      *
      * @return $this
      */
-    public function extractMultipleFrames($frameRate = ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, $destinationFolder = __DIR__)
+    public function extractMultipleFrames($frameRate = ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, $priority = 0)
     {
-        $this->media->addFilter(new ExtractMultipleFramesFilter($frameRate, $destinationFolder));
+        $this->media->addFilter(new ExtractMultipleFramesFilter($frameRate, $priority));
 
         return $this;
     }

--- a/src/FFMpeg/Format/Video/Simple.php
+++ b/src/FFMpeg/Format/Video/Simple.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Format\Video;
+
+/**
+ * The X264 video format
+ */
+class Simple extends DefaultVideo {
+    /** @var boolean */
+    private $bframesSupport = true;
+
+    /** @var integer */
+    private $passes = 1;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportBFrames() {
+        return $this->bframesSupport;
+    }
+
+    /**
+     * @param $support
+     *
+     * @return X264
+     */
+    public function setBFramesSupport($support) {
+        $this->bframesSupport = $support;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAvailableAudioCodecs() {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAvailableVideoCodecs() {
+        return [];
+    }
+
+    /**
+     * @param $passes
+     *
+     * @return X264
+     */
+    public function setPasses($passes) {
+        $this->passes = $passes;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPasses() {
+        return $this->passes;
+    }
+
+    /**
+     * @return int
+     */
+    public function getModulus() {
+        return 2;
+    }
+}

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -46,6 +46,12 @@ class ExtractMultipleFramesFilterTest extends TestCase
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'png', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'png', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'png', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'png', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'png', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.png')),
             array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
         );
     }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -12,7 +12,7 @@ class ExtractMultipleFramesFilterTest extends TestCase
     /**
      * @dataProvider provideFrameRates
      */
-    public function testApply($frameRate, $destinationFolder, $duration, $modulus, $expected)
+    public function testApply($frameRate, $frameFileType,$destinationFolder, $duration, $modulus, $expected)
     {
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
@@ -34,18 +34,19 @@ class ExtractMultipleFramesFilterTest extends TestCase
             ->will($this->returnValue($streams));
 
         $filter = new ExtractMultipleFramesFilter($frameRate, $destinationFolder);
+        $filter->setFrameFileType($frameFileType);
         $this->assertEquals($expected, $filter->apply($video, $format));
     }
 
     public function provideFrameRates()
     {
         return array(
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
         );
     }
 }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -68,7 +68,7 @@ class ExtractMultipleFramesFilterTest extends TestCase
      * @expectedException \FFMpeg\Exception\InvalidArgumentException
      */
     public function testInvalidFrameFileType() {
-    	$filter = new ExtractMultipleFramesFilter('1/1', '/');
+        $filter = new ExtractMultipleFramesFilter('1/1', '/');
         $filter->setFrameFileType('webm');
     }
 }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -41,18 +41,34 @@ class ExtractMultipleFramesFilterTest extends TestCase
     public function provideFrameRates()
     {
         return array(
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'jpg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC,'png', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC,'png', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC,'png', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC,'png', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC,'png', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC,'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
+
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpeg')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpeg')),
+
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.png')),
+            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
         );
+    }
+
+    /**
+     * @expectedException \FFMpeg\Exception\InvalidArgumentException
+     */
+    public function testInvalidFrameFileType() {
+    	$filter = new ExtractMultipleFramesFilter('1/1', '/');
+        $filter->setFrameFileType('webm');
     }
 }

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -7,68 +7,45 @@ use Tests\FFMpeg\Unit\TestCase;
 use FFMpeg\FFProbe\DataMapping\Stream;
 use FFMpeg\FFProbe\DataMapping\StreamCollection;
 
-class ExtractMultipleFramesFilterTest extends TestCase
-{
+class ExtractMultipleFramesFilterTest extends TestCase {
     /**
      * @dataProvider provideFrameRates
      */
-    public function testApply($frameRate, $frameFileType,$destinationFolder, $duration, $modulus, $expected)
-    {
+    public function testApply($frameRate, $frameFileType, $modulus, $expected) {
         $video = $this->getVideoMock();
-        $pathfile = '/path/to/file'.mt_rand();
+        $pathfile = '/path/to/file' . mt_rand();
 
         $format = $this->getMock('FFMpeg\Format\VideoInterface');
         $format->expects($this->any())
             ->method('getModulus')
             ->will($this->returnValue($modulus));
 
-        $streams = new StreamCollection(array(
-            new Stream(array(
-                'codec_type' => 'video',
-                'duration'      => $duration,
-            ))
-        ));
-
-        $video->expects($this->once())
-            ->method('getStreams')
-            ->will($this->returnValue($streams));
-
-        $filter = new ExtractMultipleFramesFilter($frameRate, $destinationFolder);
-        $filter->setFrameFileType($frameFileType);
+        $filter = new ExtractMultipleFramesFilter($frameRate, $frameFileType);
         $this->assertEquals($expected, $filter->apply($video, $format));
     }
 
-    public function provideFrameRates()
-    {
-        return array(
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpg')),
+    public function provideFrameRates() {
+        return [
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpg', 2, ['-vf', 'fps=1/1']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpg', 2, ['-vf', 'fps=1/2']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpg', 2, ['-vf', 'fps=1/5']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpg', 2, ['-vf', 'fps=1/10']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpg', 2, ['-vf', 'fps=1/30']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpg', 2, ['-vf', 'fps=1/60']],
 
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.jpeg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.jpeg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.jpeg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.jpeg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.jpeg')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpeg', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.jpeg')),
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'jpeg', 2, ['-vf', 'fps=1/1']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'jpeg', 2, ['-vf', 'fps=1/2']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'jpeg', 2, ['-vf', 'fps=1/5']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'jpeg', 2, ['-vf', 'fps=1/10']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'jpeg', 2, ['-vf', 'fps=1/30']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'jpeg', 2, ['-vf', 'fps=1/60']],
 
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/1', '/frame-%03d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/2', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/5', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/10', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/30', '/frame-%02d.png')),
-            array(ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'png', '/', 100, 2, array('-vf', 'fps=1/60', '/frame-%02d.png')),
-        );
-    }
-
-    /**
-     * @expectedException \FFMpeg\Exception\InvalidArgumentException
-     */
-    public function testInvalidFrameFileType() {
-        $filter = new ExtractMultipleFramesFilter('1/1', '/');
-        $filter->setFrameFileType('webm');
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC, 'png', 2, ['-vf', 'fps=1/1']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_2SEC, 'png', 2, ['-vf', 'fps=1/2']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_5SEC, 'png', 2, ['-vf', 'fps=1/5']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_10SEC, 'png', 2, ['-vf', 'fps=1/10']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_30SEC, 'png', 2, ['-vf', 'fps=1/30']],
+            [ExtractMultipleFramesFilter::FRAMERATE_EVERY_60SEC, 'png', 2, ['-vf', 'fps=1/60']],
+        ];
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | Yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #494 
| Related issues/PRs | #494 
| License            | MIT

#### What's in this PR?

The PR fixes ExtractMultipleFramesFilter implementation as mentioned in https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues/494#issuecomment-371645107. 

#### Why?

See #494 

#### Example Usage

```php
$video = $ffmpeg->open($url);
            $video
                ->filters()
                ->extractMultipleFrames(ExtractMultipleFramesFilter::FRAMERATE_EVERY_SEC)
```
#### BC Breaks/Deprecations

FFMpeg\Filters\Video\ExtractMultipleFramesFilter constructor has been changed. Directory is not needed anymore. 

This PR overrides https://github.com/PHP-FFMpeg/PHP-FFMpeg/pull/495 and makes it obsolete 

#### To Do?

I haven't added a unit test for `src/FFMpeg/Format/Video/Simple.php` because `VideoTestCase` expects array and data to be either greater than 1 or not empty. The purpose of Simple is not to have those. 