### PR TITLE
526: Change property type`private` with `protected`.

### DIFF
--- a/src/FFMpeg/Coordinate/AspectRatio.php
+++ b/src/FFMpeg/Coordinate/AspectRatio.php
@@ -20,7 +20,7 @@ class AspectRatio
     const AR_4_3 = '4/3';
     // named 16:9 or 1.77:1 HD video standard
     const AR_16_9 = '16/9';
-    
+
     // named 8:5 or 16:10 or 1.6:1
     const AR_8_5 = '8/5';
 
@@ -62,7 +62,7 @@ class AspectRatio
     const AR_ROTATED_2_DOT_39 = '1/2.39';
 
     /** @var float */
-    private $ratio;
+    protected $ratio;
 
     public function __construct($ratio)
     {

--- a/src/FFMpeg/Coordinate/Dimension.php
+++ b/src/FFMpeg/Coordinate/Dimension.php
@@ -18,8 +18,8 @@ use FFMpeg\Exception\InvalidArgumentException;
  */
 class Dimension
 {
-    private $width;
-    private $height;
+    protected $width;
+    protected $height;
 
     /**
      * @param integer $width

--- a/src/FFMpeg/Coordinate/FrameRate.php
+++ b/src/FFMpeg/Coordinate/FrameRate.php
@@ -15,7 +15,7 @@ use FFMpeg\Exception\InvalidArgumentException;
 
 class FrameRate
 {
-    private $value;
+    protected $value;
 
     public function __construct($value)
     {

--- a/src/FFMpeg/Coordinate/Point.php
+++ b/src/FFMpeg/Coordinate/Point.php
@@ -13,8 +13,8 @@ namespace FFMpeg\Coordinate;
 
 class Point
 {
-    private $x;
-    private $y;
+    protected $x;
+    protected $y;
 
     public function __construct($x, $y, $dynamic = false)
     {

--- a/src/FFMpeg/Coordinate/TimeCode.php
+++ b/src/FFMpeg/Coordinate/TimeCode.php
@@ -16,10 +16,10 @@ use FFMpeg\Exception\InvalidArgumentException;
 class TimeCode
 {
     //see http://www.dropframetimecode.org/
-    private $hours;
-    private $minutes;
-    private $seconds;
-    private $frames;
+    protected $hours;
+    protected $minutes;
+    protected $seconds;
+    protected $frames;
 
     public function __construct($hours, $minutes, $seconds, $frames)
     {

--- a/src/FFMpeg/FFMpeg.php
+++ b/src/FFMpeg/FFMpeg.php
@@ -22,9 +22,9 @@ use Psr\Log\LoggerInterface;
 class FFMpeg
 {
     /** @var FFMpegDriver */
-    private $driver;
+    protected $driver;
     /** @var FFProbe */
-    private $ffprobe;
+    protected $ffprobe;
 
     public function __construct(FFMpegDriver $ffmpeg, FFProbe $ffprobe)
     {

--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -34,15 +34,15 @@ class FFProbe
     const TYPE_FORMAT = 'format';
 
     /** @var Cache */
-    private $cache;
+    protected $cache;
     /** @var OptionsTesterInterface */
-    private $optionsTester;
+    protected $optionsTester;
     /** @var OutputParserInterface */
-    private $parser;
+    protected $parser;
     /** @var FFProbeDriver */
-    private $ffprobe;
+    protected $ffprobe;
     /** @var MapperInterface */
-    private $mapper;
+    protected $mapper;
 
     public function __construct(FFProbeDriver $ffprobe, Cache $cache)
     {

--- a/src/FFMpeg/FFProbe/DataMapping/AbstractData.php
+++ b/src/FFMpeg/FFProbe/DataMapping/AbstractData.php
@@ -13,7 +13,7 @@ namespace FFMpeg\FFProbe\DataMapping;
 
 abstract class AbstractData implements \Countable
 {
-    private $properties;
+    protected $properties;
 
     public function __construct(array $properties)
     {

--- a/src/FFMpeg/FFProbe/DataMapping/StreamCollection.php
+++ b/src/FFMpeg/FFProbe/DataMapping/StreamCollection.php
@@ -13,7 +13,7 @@ namespace FFMpeg\FFProbe\DataMapping;
 
 class StreamCollection implements \Countable, \IteratorAggregate
 {
-    private $streams;
+    protected $streams;
 
     public function __construct(array $streams = array())
     {

--- a/src/FFMpeg/FFProbe/OptionsTester.php
+++ b/src/FFMpeg/FFProbe/OptionsTester.php
@@ -19,9 +19,9 @@ use FFMpeg\Exception\RuntimeException;
 class OptionsTester implements OptionsTesterInterface
 {
     /** @var FFProbeDriver */
-    private $ffprobe;
+    protected $ffprobe;
     /** @var Cache */
-    private $cache;
+    protected $cache;
 
     public function __construct(FFProbeDriver $ffprobe, Cache $cache)
     {

--- a/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
+++ b/src/FFMpeg/Filters/Audio/AddMetadataFilter.php
@@ -18,9 +18,9 @@ use FFMpeg\Media\Audio;
 class AddMetadataFilter implements AudioFilterInterface
 {
 	/** @var Array */
-	private $metaArr;
+	protected $metaArr;
 	/** @var Integer */
-	private $priority;
+	protected $priority;
 
 	function __construct($metaArr = null, $priority = 9)
 	{

--- a/src/FFMpeg/Filters/Audio/AudioClipFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioClipFilter.php
@@ -20,17 +20,17 @@ class AudioClipFilter implements AudioFilterInterface {
     /**
      * @var TimeCode
      */
-    private $start;
+    protected $start;
 
     /**
      * @var TimeCode
      */
-    private $duration;
+    protected $duration;
 
     /**
      * @var int
      */
-    private $priority;
+    protected $priority;
 
 
     public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0) {

--- a/src/FFMpeg/Filters/Audio/AudioResamplableFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioResamplableFilter.php
@@ -17,9 +17,9 @@ use FFMpeg\Media\Audio;
 class AudioResamplableFilter implements AudioFilterInterface
 {
     /** @var string */
-    private $rate;
+    protected $rate;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     public function __construct($rate, $priority = 0)
     {

--- a/src/FFMpeg/Filters/Audio/SimpleFilter.php
+++ b/src/FFMpeg/Filters/Audio/SimpleFilter.php
@@ -16,8 +16,8 @@ use FFMpeg\Format\AudioInterface;
 
 class SimpleFilter implements AudioFilterInterface
 {
-    private $params;
-    private $priority;
+    protected $params;
+    protected $priority;
 
     public function __construct(array $params, $priority = 0)
     {

--- a/src/FFMpeg/Filters/Concat/ConcatFilters.php
+++ b/src/FFMpeg/Filters/Concat/ConcatFilters.php
@@ -15,7 +15,7 @@ use FFMpeg\Media\Concat;
 
 class ConcatFilters
 {
-    private $concat;
+    protected $concat;
 
     public function __construct(Concat $concat)
     {

--- a/src/FFMpeg/Filters/FiltersCollection.php
+++ b/src/FFMpeg/Filters/FiltersCollection.php
@@ -13,8 +13,8 @@ namespace FFMpeg\Filters;
 
 class FiltersCollection implements \Countable, \IteratorAggregate
 {
-    private $sorted;
-    private $filters = array();
+    protected $sorted;
+    protected $filters = array();
 
     /**
      * @param FilterInterface $filter

--- a/src/FFMpeg/Filters/Frame/DisplayRatioFixerFilter.php
+++ b/src/FFMpeg/Filters/Frame/DisplayRatioFixerFilter.php
@@ -17,7 +17,7 @@ use FFMpeg\Media\Frame;
 class DisplayRatioFixerFilter implements FrameFilterInterface
 {
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     public function __construct($priority = 0)
     {

--- a/src/FFMpeg/Filters/Frame/FrameFilters.php
+++ b/src/FFMpeg/Filters/Frame/FrameFilters.php
@@ -15,7 +15,7 @@ use FFMpeg\Media\Frame;
 
 class FrameFilters
 {
-    private $frame;
+    protected $frame;
 
     public function __construct(Frame $frame)
     {

--- a/src/FFMpeg/Filters/Gif/GifFilters.php
+++ b/src/FFMpeg/Filters/Gif/GifFilters.php
@@ -15,7 +15,7 @@ use FFMpeg\Media\Gif;
 
 class GifFilters
 {
-    private $gif;
+    protected $gif;
 
     public function __construct(Gif $gif)
     {

--- a/src/FFMpeg/Filters/Video/ClipFilter.php
+++ b/src/FFMpeg/Filters/Video/ClipFilter.php
@@ -18,11 +18,11 @@ use FFMpeg\Coordinate\TimeCode;
 class ClipFilter implements VideoFilterInterface
 {
     /** @var TimeCode */
-    private $start;
+    protected $start;
     /** @var TimeCode */
-    private $duration;
+    protected $duration;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0)
     {

--- a/src/FFMpeg/Filters/Video/CustomFilter.php
+++ b/src/FFMpeg/Filters/Video/CustomFilter.php
@@ -16,9 +16,9 @@ use FFMpeg\Media\Video;
 class CustomFilter implements VideoFilterInterface
 {
     /** @var string */
-    private $filter;
+    protected $filter;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     /**
      * A custom filter, useful if you want to build complex filters

--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -32,9 +32,9 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     const FRAMERATE_EVERY_60SEC = '1/60';
 
     /** @var integer */
-    private $priority;
-    private $frameRate;
-    private $destinationFolder;
+    protected $priority;
+    protected $frameRate;
+    protected $destinationFolder;
 
     public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $destinationFolder = __DIR__, $priority = 0)
     {

--- a/src/FFMpeg/Filters/Video/FrameRateFilter.php
+++ b/src/FFMpeg/Filters/Video/FrameRateFilter.php
@@ -17,9 +17,9 @@ use FFMpeg\Format\VideoInterface;
 
 class FrameRateFilter implements VideoFilterInterface
 {
-    private $rate;
-    private $gop;
-    private $priority;
+    protected $rate;
+    protected $gop;
+    protected $priority;
 
     public function __construct(FrameRate $rate, $gop, $priority = 0)
     {

--- a/src/FFMpeg/Filters/Video/PadFilter.php
+++ b/src/FFMpeg/Filters/Video/PadFilter.php
@@ -18,9 +18,9 @@ use FFMpeg\Format\VideoInterface;
 class PadFilter implements VideoFilterInterface
 {
     /** @var Dimension */
-    private $dimension;
+    protected $dimension;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     public function __construct(Dimension $dimension, $priority = 0)
     {

--- a/src/FFMpeg/Filters/Video/ResizeFilter.php
+++ b/src/FFMpeg/Filters/Video/ResizeFilter.php
@@ -28,13 +28,13 @@ class ResizeFilter implements VideoFilterInterface
     const RESIZEMODE_SCALE_HEIGHT = 'height';
 
     /** @var Dimension */
-    private $dimension;
+    protected $dimension;
     /** @var string */
-    private $mode;
+    protected $mode;
     /** @var Boolean */
-    private $forceStandards;
+    protected $forceStandards;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     public function __construct(Dimension $dimension, $mode = self::RESIZEMODE_FIT, $forceStandards = true, $priority = 0)
     {
@@ -101,7 +101,7 @@ class ResizeFilter implements VideoFilterInterface
             // Using Filter to have ordering
             $commands[] = '-vf';
             $commands[] = '[in]scale=' . $dimensions->getWidth() . ':' . $dimensions->getHeight() . ' [out]';
-            
+
         }
 
         return $commands;

--- a/src/FFMpeg/Filters/Video/RotateFilter.php
+++ b/src/FFMpeg/Filters/Video/RotateFilter.php
@@ -23,9 +23,9 @@ class RotateFilter implements VideoFilterInterface
     const ROTATE_270 = 'transpose=2';
 
     /** @var string */
-    private $angle;
+    protected $angle;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     public function __construct($angle, $priority = 0)
     {

--- a/src/FFMpeg/Filters/Video/SynchronizeFilter.php
+++ b/src/FFMpeg/Filters/Video/SynchronizeFilter.php
@@ -19,7 +19,7 @@ use FFMpeg\Media\Video;
  */
 class SynchronizeFilter implements VideoFilterInterface
 {
-    private $priority;
+    protected $priority;
 
     public function __construct($priority = 12)
     {

--- a/src/FFMpeg/Filters/Video/WatermarkFilter.php
+++ b/src/FFMpeg/Filters/Video/WatermarkFilter.php
@@ -18,11 +18,11 @@ use FFMpeg\Media\Video;
 class WatermarkFilter implements VideoFilterInterface
 {
     /** @var string */
-    private $watermarkPath;
+    protected $watermarkPath;
     /** @var array */
-    private $coordinates;
+    protected $coordinates;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     public function __construct($watermarkPath, array $coordinates = array(), $priority = 0)
     {

--- a/src/FFMpeg/Filters/Waveform/WaveformDownmixFilter.php
+++ b/src/FFMpeg/Filters/Waveform/WaveformDownmixFilter.php
@@ -18,9 +18,9 @@ class WaveformDownmixFilter implements WaveformFilterInterface
 {
 
     /** @var boolean */
-    private $downmix;
+    protected $downmix;
     /** @var integer */
-    private $priority;
+    protected $priority;
 
     // By default, the downmix value is set to FALSE.
     public function __construct($downmix = FALSE, $priority = 0)
@@ -55,12 +55,12 @@ class WaveformDownmixFilter implements WaveformFilterInterface
         foreach ($waveform->getAudio()->getStreams() as $stream) {
             if ($stream->isAudio()) {
                 try {
-                    
+
                     // If the downmix parameter is set to TRUE, we add an option to the FFMPEG command
                     if($this->downmix == TRUE) {
                         $commands[] = '"aformat=channel_layouts=mono"';
                     }
-                    
+
                     break;
 
                 } catch (RuntimeException $e) {

--- a/src/FFMpeg/Filters/Waveform/WaveformFilters.php
+++ b/src/FFMpeg/Filters/Waveform/WaveformFilters.php
@@ -15,7 +15,7 @@ use FFMpeg\Media\Waveform;
 
 class WaveformFilters
 {
-    private $waveform;
+    protected $waveform;
 
     public function __construct(Waveform $waveform)
     {

--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -22,34 +22,34 @@ use FFMpeg\Exception\RuntimeException;
 abstract class AbstractProgressListener extends EventEmitter implements ListenerInterface
 {
     /** @var integer */
-    private $duration;
+    protected $duration;
 
     /** @var integer */
-    private $totalSize;
+    protected $totalSize;
 
     /** @var integer */
-    private $currentSize;
+    protected $currentSize;
 
     /** @var integer */
-    private $currentTime;
+    protected $currentTime;
 
     /** @var double */
-    private $lastOutput = null;
+    protected $lastOutput = null;
 
     /** @var FFProbe */
-    private $ffprobe;
+    protected $ffprobe;
 
     /** @var string */
-    private $pathfile;
+    protected $pathfile;
 
     /** @var Boolean */
-    private $initialized = false;
+    protected $initialized = false;
 
     /** @var integer */
-    private $currentPass;
+    protected $currentPass;
 
     /** @var integer */
-    private $totalPass;
+    protected $totalPass;
 
     /**
      * Transcoding rate in kb/s

--- a/src/FFMpeg/Media/AbstractStreamableMedia.php
+++ b/src/FFMpeg/Media/AbstractStreamableMedia.php
@@ -16,7 +16,7 @@ use FFMpeg\FFProbe\DataMapping\StreamCollection;
 
 abstract class AbstractStreamableMedia extends AbstractMediaType
 {
-    private $streams;
+    protected $streams;
 
     /**
      * @return StreamCollection

--- a/src/FFMpeg/Media/Concat.php
+++ b/src/FFMpeg/Media/Concat.php
@@ -29,7 +29,7 @@ use Neutron\TemporaryFilesystem\Manager as FsManager;
 class Concat extends AbstractMediaType
 {
     /** @var array */
-    private $sources;
+    protected $sources;
 
     public function __construct($sources, FFMpegDriver $driver, FFProbe $ffprobe)
     {

--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -22,9 +22,9 @@ use FFMpeg\Coordinate\TimeCode;
 class Frame extends AbstractMediaType
 {
     /** @var TimeCode */
-    private $timecode;
+    protected $timecode;
     /** @var Video */
-    private $video;
+    protected $video;
 
     public function __construct(Video $video, FFMpegDriver $driver, FFProbe $ffprobe, TimeCode $timecode)
     {
@@ -106,7 +106,7 @@ class Frame extends AbstractMediaType
                 '-f', $outputFormat
             );
         }
-        
+
         if($returnBase64) {
             array_push($commands, "-");
         }

--- a/src/FFMpeg/Media/Gif.php
+++ b/src/FFMpeg/Media/Gif.php
@@ -23,13 +23,13 @@ use FFMpeg\Coordinate\Dimension;
 class Gif extends AbstractMediaType
 {
     /** @var TimeCode */
-    private $timecode;
+    protected $timecode;
     /** @var Dimension */
-    private $dimension;
+    protected $dimension;
     /** @var integer */
-    private $duration;
+    protected $duration;
     /** @var Video */
-    private $video;
+    protected $video;
 
     public function __construct(Video $video, FFMpegDriver $driver, FFProbe $ffprobe, TimeCode $timecode, Dimension $dimension, $duration = null)
     {


### PR DESCRIPTION
https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues/526

| Q              | A
| -------------- | ---
| Bug?           | no
| New Feature?   | no
| Version Used   | 0.6.0
| FFmpeg Version | FFmpeg version 3.4
| OS             | Linux dec9410c9e72 4.4.0-119-generic #143-Ubuntu

Could you please change `private` properties in `FFMpeg/FFMpeg.php` on `protected`?
It helps easy to extend the class for more/custom functionality.

`FFMpeg/FFMpeg.php`
```
    /** @var FFMpegDriver */
    private $driver;
    /** @var FFProbe */
    private $ffprobe;
```

`FFMpeg/FFProbe.php`
```
    /** @var Cache */
    private $cache;
    /** @var OptionsTesterInterface */
    private $optionsTester;
    /** @var OutputParserInterface */
    private $parser;
    /** @var FFProbeDriver */
    private $ffprobe;
    /** @var MapperInterface */
    private $mapper;
```