### PR TITLE
fix a bug when calling Frame->save()

### DIFF
--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -115,8 +115,7 @@ class Frame extends AbstractMediaType
             $commands = array_merge($commands, $filter->apply($this));
         }
 
-        // without output filename when return binary string
-        if(!$returnBase64) {
+        if (!$returnBase64) {
             $commands = array_merge($commands, array($pathfile));
         }
 

--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -115,7 +115,10 @@ class Frame extends AbstractMediaType
             $commands = array_merge($commands, $filter->apply($this));
         }
 
-        $commands = array_merge($commands, array($pathfile));
+        // without output filename when return binary string
+        if(!$returnBase64) {
+            $commands = array_merge($commands, array($pathfile));
+        }
 
         try {
             if(!$returnBase64) {

--- a/tests/Unit/Media/FrameTest.php
+++ b/tests/Unit/Media/FrameTest.php
@@ -61,7 +61,9 @@ class FrameTest extends AbstractMediaTestCase
 
         $pathfile = '/target/destination';
 
-        array_push($commands, $pathfile);
+        if (!$base64) {
+            array_push($commands, $pathfile);
+        }
 
         $driver->expects($this->once())
             ->method('command')


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #532
| Related issues/PRs | #532
| License            | MIT


fix a bug in src/FFMpeg/Media/Frame.php when calling Frame->save()，Add a judgment when the $pathfile be spliced