### PR TITLE
Use native aac format

### DIFF
--- a/src/FFMpeg/Format/Audio/Aac.php
+++ b/src/FFMpeg/Format/Audio/Aac.php
@@ -19,7 +19,7 @@ class Aac extends DefaultAudio
 
     public function __construct()
     {
-        $this->audioCodec = 'libfdk_aac';
+        $this->audioCodec = 'aac';
     }
 
     /**
@@ -27,6 +27,6 @@ class Aac extends DefaultAudio
      */
     public function getAvailableAudioCodecs(): array
     {
-        return ['libfdk_aac'];
+        return ['aac', 'libfdk_aac'];
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

‘AAC’ is the native codec and ‘libfdk_aac’ only exists if compiled in during the build process. This PR switches the 'aac' to the default.

#### Why?

#567