### PR TITLE
Add missin typehint to FFMpeg/Media/AbstractVideo

### DIFF
--- a/src/FFMpeg/Media/AbstractVideo.php
+++ b/src/FFMpeg/Media/AbstractVideo.php
@@ -122,7 +122,7 @@ abstract class AbstractVideo extends Audio
      * NOTE: This method is different to the Audio's one, because Video is using passes.
      * @inheritDoc
      */
-    public function getFinalCommand(FormatInterface $format, $outputPathfile)
+    public function getFinalCommand(FormatInterface $format, string $outputPathfile)
     {
         $finalCommands = [];
 
@@ -141,7 +141,7 @@ abstract class AbstractVideo extends Audio
      * @inheritDoc
      * @return string[][]
      */
-    protected function buildCommand(FormatInterface $format, $outputPathfile)
+    protected function buildCommand(FormatInterface $format, string $outputPathfile)
     {
         $commands = $this->basePartOfCommand();
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Related issues/PRs | #570 
| License            | MIT

#### What's in this PR?

Add missing typehint to FFMpeg/Media/AbstractVideo

#### Why?

Parent class's methods has different signature.
in parrent:
FFMpeg\Media\Audio has
- getFinalCommand(FormatInterface $format, string $outputPathfile)
https://github.com/PHP-FFMpeg/PHP-FFMpeg/blob/dd47d409667621230a49205acde029a1df9561dd/src/FFMpeg/Media/Audio.php#L90
- buildCommand(FormatInterface $format, string $outputPathfile)
https://github.com/PHP-FFMpeg/PHP-FFMpeg/blob/dd47d409667621230a49205acde029a1df9561dd/src/FFMpeg/Media/Audio.php#L103

FFMpeg\Media\AbstractVideo has
- getFinalCommand(FormatInterface $format, $outputPathfile)
https://github.com/PHP-FFMpeg/PHP-FFMpeg/blob/dd47d409667621230a49205acde029a1df9561dd/src/FFMpeg/Media/AbstractVideo.php#L125
- buildCommand(FormatInterface $format, $outputPathfile)
https://github.com/PHP-FFMpeg/PHP-FFMpeg/blob/dd47d409667621230a49205acde029a1df9561dd/src/FFMpeg/Media/AbstractVideo.php#L144
