### PR TITLE
Add compatibility to the latest BinaryDriver version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": "^5.3.9 || ^7.0",
-        "alchemy/binary-driver": "^1.5 || ~2.0.0",
+        "alchemy/binary-driver": "^1.5 || ~2.0.0 || ^5.0",
         "doctrine/cache": "^1.0",
         "evenement/evenement": "^2.0 || ^1.0",
         "neutron/temporary-filesystem": "^2.1.1"


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | N/A
| Related issues/PRs | N/A
| License            | MIT

#### What's in this PR?

I add the latest BinaryDriver version constraint as it seems there was an issue with tags v2.0.0, v4.1,...
You can have a look at https://github.com/alchemy-fr/BinaryDriver/issues/25 
