### PR TITLE
concat allow special chars in filename

### DIFF
--- a/src/FFMpeg/Media/Concat.php
+++ b/src/FFMpeg/Media/Concat.php
@@ -105,7 +105,7 @@ class Concat extends AbstractMediaType
                 if($count_videos != 0)
                     $line .= "\n";
 
-                $line .= "file ".$videoPath;
+                $line .= "file " . addcslashes($videoPath, '\'"\\\0 ');
 
                 fwrite($fileStream, $line);
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         |  if someone did a workaround themselves
| Deprecations?      | no
| License            | MIT

#### Why?

The [concatenation](https://github.com/PHP-FFMpeg/PHP-FFMpeg#concatenation) does not work if there is a space or \ (backslash) in one of the source file paths. (In windows its very likely that there is a \ in the path, so for me the concatenation did not work)

#### What's in this PR?

adds \ before the characters ', ", \, SPACE and NUL

related ffmpeg docs: https://ffmpeg.org/ffmpeg-formats.html#concat
> Path to a file to read; special characters and spaces must be escaped with backslash or single quotes. 

example of the temp file before the code change (which did not work)
```
file C:\Users\Roland\Documents\MyStuff\programmieren\PHP-FFMpeg/small '.mp4
file C:\Users\Roland\Documents\MyStuff\programmieren\PHP-FFMpeg/small '.mp4
```
now it looks like this
```
file C:\\Users\\Roland\\Documents\\MyStuff\\programmieren\\PHP-FFMpeg/small\ \'.mp4
file C:\\Users\\Roland\\Documents\\MyStuff\\programmieren\\PHP-FFMpeg/small\ \'.mp4
```

#### Example Usage

```php
<?php

require 'vendor/autoload.php';

$ffmpeg = FFMpeg\FFMpeg::create();
$video = $ffmpeg->open(__DIR__ . "/small '.mp4");
$video
    ->concat([__DIR__ . "/small '.mp4", __DIR__ . "/small '.mp4"])
    ->saveFromSameCodecs(__DIR__ . '/out-'.  time() . '.mp4', true);
```

