### PR TITLE
Added custom filters for Audio, in the same way as custom filters are available for Video

### DIFF
--- a/src/FFMpeg/Filters/Audio/AudioFilters.php
+++ b/src/FFMpeg/Filters/Audio/AudioFilters.php
@@ -71,4 +71,18 @@ class AudioFilters
 
         return $this;
     }
+
+    /**
+     * Applies a custom filter
+     *
+     * @param string    $parameters
+     *
+     * @return AudioFilters
+     */
+    public function custom($parameters)
+    {
+        $this->media->addFilter(new CustomFilter($parameters));
+
+        return $this;
+    }
 }

--- a/src/FFMpeg/Filters/Audio/CustomFilter.php
+++ b/src/FFMpeg/Filters/Audio/CustomFilter.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <dev.team@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace FFMpeg\Filters\Audio;
+
+use FFMpeg\Format\AudioInterface;
+use FFMpeg\Media\Audio;
+
+class CustomFilter implements AudioFilterInterface
+{
+    /** @var string */
+    private $filter;
+    /** @var integer */
+    private $priority;
+
+    /**
+     * A custom filter, useful if you want to build complex filters
+     *
+     * @param string $filter
+     * @param int    $priority
+     */
+    public function __construct($filter, $priority = 0)
+    {
+        $this->filter = $filter;
+        $this->priority = $priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Audio $audio, AudioInterface $format)
+    {
+        $commands = array('-af', $this->filter);
+
+        return $commands;
+    }
+}

--- a/tests/Unit/Filters/Audio/CustomFilterTest.php
+++ b/tests/Unit/Filters/Audio/CustomFilterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Filters\Audio;
+
+use FFMpeg\Filters\Audio\CustomFilter;
+use FFMpeg\Filters\Audio\FrameRateFilter;
+use Tests\FFMpeg\Unit\TestCase;
+use FFMpeg\Coordinate\FrameRate;
+
+class CustomFilterTest extends TestCase
+{
+    public function testApplyCustomFilter()
+    {
+        $audio = $this->getAudioMock();
+        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+
+        $filter = new CustomFilter('whatever i put would end up as a filter');
+        $this->assertEquals(array('-af', 'whatever i put would end up as a filter'), $filter->apply($audio, $format));
+    }
+}


### PR DESCRIPTION
… available for Video

| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | N/A
| Related issues/PRs | N/A
| License            | MIT

#### What's in this PR?

Added custom filters for Audio, in the same way as custom filters are available for Video.

#### Why?

Allows custom filters to be used for Audio.

#### Example Usage

$audio->filters()->custom('loudnorm=I=-13');

#### Tests

Added relevant Unit Tests
