### PR TITLE
Strict comparison for -vf check

### DIFF
--- a/src/FFMpeg/Media/AbstractVideo.php
+++ b/src/FFMpeg/Media/AbstractVideo.php
@@ -206,7 +206,7 @@ abstract class AbstractVideo extends Audio
         $videoFilterVars = $videoFilterProcesses = array();
         for ($i = 0; $i < count($commands); $i++) {
             $command = $commands[$i];
-            if ($command == '-vf') {
+            if ($command === '-vf') {
                 $commandSplits = explode(";", $commands[$i + 1]);
                 if (count($commandSplits) == 1) {
                     $commandSplit = $commandSplits[0];


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | n/a
| Related issues/PRs | n/a
| License            | MIT

#### What's in this PR?
This fixes an edge case where php with the simple equal operator (==) considers  0 and "-vf" as equal

#### Why?
Out of bounds array access/attempted merging of arguments that are not filters

#### Example Usage
n/a
