### PR TITLE
added custom frame filter

### DIFF
--- a/src/FFMpeg/Filters/Frame/CustomFrameFilter.php
+++ b/src/FFMpeg/Filters/Frame/CustomFrameFilter.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <dev.team@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Filters\Frame;
+
+use FFMpeg\Exception\RuntimeException;
+use FFMpeg\Media\Frame;
+
+class CustomFrameFilter implements FrameFilterInterface
+{
+    /** @var string */
+    private $filter;
+    /** @var integer */
+    private $priority;
+
+    /**
+     * A custom filter, useful if you want to build complex filters
+     *
+     * @param string $filter
+     * @param int    $priority
+     */
+    public function __construct($filter, $priority = 0)
+    {
+        $this->filter = $filter;
+        $this->priority = $priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(Frame $frame)
+    {
+        $commands = array('-vf', $this->filter);
+
+        return $commands;
+    }
+}
+

--- a/src/FFMpeg/Filters/Frame/FrameFilters.php
+++ b/src/FFMpeg/Filters/Frame/FrameFilters.php
@@ -36,4 +36,18 @@ class FrameFilters
 
         return $this;
     }
+
+    /**
+     * Applies a custom filter: -vf foo bar
+     *
+     * @param string    $parameters
+     *
+     * @return FrameFilters
+     */
+    public function custom($parameters)
+    {
+        $this->frame->addFilter(new CustomFrameFilter($parameters));
+
+        return $this;
+    }
 }

--- a/tests/Unit/Filters/Frame/CustomFrameFilterTest.php
+++ b/tests/Unit/Filters/Frame/CustomFrameFilterTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Filters\Frame;
+
+use FFMpeg\Filters\Frame\CustomFrameFilter;
+use Tests\FFMpeg\Unit\TestCase;
+
+class CustomFrameFilterTest extends TestCase
+{
+    public function testApplyCustomFrameFilter()
+    {
+	$frame = $this->getFrameMock();
+
+	$filter = new CustomFrameFilter('whatever i put would end up as a filter');
+        $this->assertEquals(array('-vf', 'whatever i put would end up as a filter'), $filter->apply($frame));
+    }
+}

--- a/tests/Unit/Filters/Frame/CustomFrameFilterTest.php
+++ b/tests/Unit/Filters/Frame/CustomFrameFilterTest.php
@@ -9,9 +9,9 @@ class CustomFrameFilterTest extends TestCase
 {
     public function testApplyCustomFrameFilter()
     {
-	$frame = $this->getFrameMock();
+        $frame = $this->getFrameMock();
 
-	$filter = new CustomFrameFilter('whatever i put would end up as a filter');
-	$this->assertEquals(array('-vf', 'whatever i put would end up as a filter'), $filter->apply($frame));
+        $filter = new CustomFrameFilter('whatever i put would end up as a filter');
+        $this->assertEquals(array('-vf', 'whatever i put would end up as a filter'), $filter->apply($frame));
     }
 }

--- a/tests/Unit/Filters/Frame/CustomFrameFilterTest.php
+++ b/tests/Unit/Filters/Frame/CustomFrameFilterTest.php
@@ -12,6 +12,6 @@ class CustomFrameFilterTest extends TestCase
 	$frame = $this->getFrameMock();
 
 	$filter = new CustomFrameFilter('whatever i put would end up as a filter');
-        $this->assertEquals(array('-vf', 'whatever i put would end up as a filter'), $filter->apply($frame));
+	$this->assertEquals(array('-vf', 'whatever i put would end up as a filter'), $filter->apply($frame));
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #610 
| Related issues/PRs | #610 
| License            | MIT

#### What's in this PR?

This adds a custom filter to frame

#### Why?

E.g. it's possible to create image tiles from a video, see example code.

#### Example Usage

```php
$ffmpeg = FFMpeg\FFMpeg::create();
$video = $ffmpeg->open('/some/video.mp4');
$video->frame(FFMpeg\Coordinate\TimeCode::fromSeconds(0))
      ->addFilter(new CustomFrameFilter('scale=142:80,fps=1,tile=10x10:margin=2:padding=2'))
      ->save('/some/picture.jpg');