### PR TITLE
Add copy as available codecs for X264 and WebM

### DIFF
--- a/src/FFMpeg/Format/Video/WebM.php
+++ b/src/FFMpeg/Format/Video/WebM.php
@@ -44,7 +44,7 @@ class WebM extends DefaultVideo
      */
     public function getAvailableAudioCodecs()
     {
-        return array('libvorbis');
+        return array('copy', 'libvorbis');
     }
 
     /**

--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -54,7 +54,7 @@ class X264 extends DefaultVideo
      */
     public function getAvailableAudioCodecs()
     {
-        return array('aac', 'libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac');
+        return array('copy', 'aac', 'libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac');
     }
 
     /**


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #645 
| Related issues/PRs | #645 
| License            | MIT

#### What's in this PR?

Allows to pass 'copy' as audio codec for X264 and WebM Video Formats

#### Why?

Allowing to pass 'copy' as audio codec is very useful when you don't need/care about an specific audio codec and you just want to use the same original codec. This also avoids re-encoding the audio, thus making the transcode process faster.

This PR just adds 'copy' as an available audio codecs for both formats, so there are not breaking changes and neither new tests because there are alredy tests for getAvailableCodecs.

#### Example Usage

```php
$format = new X264('copy');
$format->save();
```
