### PR TITLE
Output exact FFMpeg error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": "^5.3.9 || ^7.0",
-        "alchemy/binary-driver": "^1.5 || ~2.0.0 || ^5.0",
+        "alchemy/binary-driver": "^1.5 || ~2.0.0 || ^5.1",
         "doctrine/cache": "^1.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "neutron/temporary-filesystem": "^2.1.1"

--- a/src/FFMpeg/Exception/CommandExecutionException.php
+++ b/src/FFMpeg/Exception/CommandExecutionException.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace FFMpeg\Exception;
+
+
+use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+
+class CommandExecutionException extends RuntimeException
+{
+    /**
+     * CommandExecutionException constructor.
+     * @param ExecutionFailureException $executionFailureException
+     */
+    public function __construct($executionFailureException, $code)
+    {
+        // For BinaryDriver > 5.1
+        if(method_exists($executionFailureException, 'getErrorOutput')){
+            $err_output = $executionFailureException->getErrorOutput();
+            $message = sprintf("Encoding failed due to the following error:\n\nError Output:\n\n %s ", $err_output);
+        }
+        // Generic message for older versions of BinaryDriver
+        else{
+            $message = "Encoding failed";
+        }
+
+        parent::__construct($message, $code, $executionFailureException);
+
+    }
+
+}

--- a/src/FFMpeg/Media/AbstractVideo.php
+++ b/src/FFMpeg/Media/AbstractVideo.php
@@ -10,6 +10,7 @@
 namespace FFMpeg\Media;
 
 use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use FFMpeg\Exception\CommandExecutionException;
 use FFMpeg\Filters\Audio\SimpleFilter;
 use FFMpeg\Exception\InvalidArgumentException;
 use FFMpeg\Exception\RuntimeException;
@@ -103,7 +104,7 @@ abstract class AbstractVideo extends Audio
         $this->fs->clean($this->fsId);
 
         if (null !== $failure) {
-            throw new RuntimeException('Encoding failed', $failure->getCode(), $failure);
+            throw new CommandExecutionException($failure, $failure->getCode());
         }
 
         return $this;

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -12,6 +12,7 @@
 namespace FFMpeg\Media;
 
 use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use FFMpeg\Exception\CommandExecutionException;
 use FFMpeg\Filters\Audio\AudioFilters;
 use FFMpeg\Format\FormatInterface;
 use FFMpeg\Filters\Audio\SimpleFilter;
@@ -71,7 +72,7 @@ class Audio extends AbstractStreamableMedia
             $this->driver->command($commands, false, $listeners);
         } catch (ExecutionFailureException $e) {
             $this->cleanupTemporaryFile($outputPathfile);
-            throw new RuntimeException('Encoding failed', $e->getCode(), $e);
+            throw new CommandExecutionException($e, $e->getCode());
         }
 
         return $this;

--- a/tests/Unit/FFProbe/OptionsTesterTest.php
+++ b/tests/Unit/FFProbe/OptionsTesterTest.php
@@ -20,7 +20,7 @@ class OptionsTesterTest extends TestCase
         $ffprobe->expects($this->once())
             ->method('command')
             ->with(array('-help', '-loglevel', 'quiet'))
-            ->will($this->throwException(new ExecutionFailureException('Failed to execute')));
+            ->will($this->throwException(new ExecutionFailureException('ffprobe', 'Failed to execute')));
 
         $tester = new OptionsTester($ffprobe, $cache);
         $tester->has('-print_format');

--- a/tests/Unit/Media/AudioTest.php
+++ b/tests/Unit/Media/AudioTest.php
@@ -76,13 +76,43 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getConfiguration')
             ->will($this->returnValue($configuration));
 
-        $failure = new ExecutionFailureException('failed to encode');
+        $failure = new ExecutionFailureException('ffmpeg', 'failed to encode');
         $driver->expects($this->once())
             ->method('command')
             ->will($this->throwException($failure));
 
         $audio = new Audio(__FILE__, $driver, $ffprobe);
         $this->setExpectedException('FFMpeg\Exception\RuntimeException');
+        $audio->save($format, $outputPathfile);
+    }
+
+    /**
+     * @requires PHP >= 5.5
+     */
+    public function testOutputsFullError()
+    {
+        $driver = $this->getFFMpegDriverMock();
+        $ffprobe = $this->getFFProbeMock();
+        $outputPathfile = '/target/file';
+
+        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format->expects($this->any())
+            ->method('getExtraParams')
+            ->will($this->returnValue(array()));
+
+        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+
+        $driver->expects($this->any())
+            ->method('getConfiguration')
+            ->will($this->returnValue($configuration));
+
+        $failure = new ExecutionFailureException('ffmpeg', 'failed to encode', 'invalid file');
+        $driver->expects($this->once())
+            ->method('command')
+            ->will($this->throwException($failure));
+
+        $audio = new Audio(__FILE__, $driver, $ffprobe);
+        $this->setExpectedException('FFMpeg\Exception\CommandExecutionException', 'invalid file');
         $audio->save($format, $outputPathfile);
     }
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #647
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Following up the new available methods on ExecutionFailureException to get the error output, this PR changes the error output when a video or audio encoding fails. To ensure compatibility with older versions of the BinaryDriver, a new exception class was created called CommandExecutionFailure, which receives as argument an instance of ExecutionFailureException, and checks if the instance has the method to get the full error output, in which case it appends the error output to the message. Otherwise it defaults to the generic "Encoding failed" message. Two tests were created to ensure that the full error output is obtained when a video or audio encoding fails.

#### Why?

It allows to much easier debugging when working with this awesome library

#### Example Usage

Now the error messages would be something like:

Encoding failed due to the following error:

(Full error output would be here)
