### PR TITLE
Allow extracting of frames without encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ $video
     ->synchronize();
 
 $video
-    ->->save(new FFMpeg\Format\Video\X264(), '/path/to/new/file');
+    ->save(new FFMpeg\Format\Video\X264(), '/path/to/new/file');
 ```
 
 If you want to extract multiple images from the video without encoding to a video use this method:

--- a/README.md
+++ b/README.md
@@ -153,8 +153,16 @@ $video
     ->synchronize();
 
 $video
-    ->save(new FFMpeg\Format\Video\X264(), '/path/to/new/file');
+    ->->save(new FFMpeg\Format\Video\X264(), '/path/to/new/file');
 ```
+
+If you want to extract multiple images from the video without encoding to a video use this method:
+
+```php
+$frames = $video->frames(FFMpeg\Media\Frames::FRAMERATE_EVERY_10SEC);
+$frames->save('/path/to/destination');
+```
+
 By default, this will save the frames as `jpg` images.
 
 You are able to override this using `setFrameFileType` to save the frames in another format:

--- a/src/FFMpeg/Filters/Frames/FramesFilterInterface.php
+++ b/src/FFMpeg/Filters/Frames/FramesFilterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Filters\Frames;
+
+use FFMpeg\Filters\FilterInterface;
+use FFMpeg\Media\Frames;
+
+interface FramesFilterInterface extends FilterInterface
+{
+    public function apply(Frames $concat);
+}

--- a/src/FFMpeg/Filters/Frames/FramesFilters.php
+++ b/src/FFMpeg/Filters/Frames/FramesFilters.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Filters\Frames;
+
+use FFMpeg\Media\Frames;
+
+class FramesFilters
+{
+    private $frames;
+
+    public function __construct(Frames $frames)
+    {
+        $this->frames = $frames;
+    }
+}

--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -16,6 +16,9 @@ use FFMpeg\Exception\RuntimeException;
 use FFMpeg\Media\Video;
 use FFMpeg\Format\VideoInterface;
 
+/**
+ * @deprecated Use \FFMpeg\Media\Video::frames instead
+ */
 class ExtractMultipleFramesFilter implements VideoFilterInterface
 {
     /** will extract a frame every second */
@@ -38,7 +41,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
     private $frameFileType = 'jpg';
 
     /** @var array */
-    private static $supportedFrameFileTypes = ['jpg', 'jpeg', 'png'];
+    private static $supportedFrameFileTypes = array('jpg', 'jpeg', 'png');
 
     public function __construct($frameRate = self::FRAMERATE_EVERY_SEC, $destinationFolder = __DIR__, $priority = 0)
     {
@@ -93,6 +96,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
 
     /**
      * {@inheritdoc}
+     * @deprecated Use \FFMpeg\Media\Video::frames instead
      */
     public function apply(Video $video, VideoInterface $format)
     {

--- a/src/FFMpeg/Media/Frames.php
+++ b/src/FFMpeg/Media/Frames.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Media;
+
+use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use FFMpeg\Exception\InvalidArgumentException;
+use FFMpeg\Driver\FFMpegDriver;
+use FFMpeg\FFProbe;
+use FFMpeg\Exception\RuntimeException;
+use FFMpeg\Filters\Frames\FramesFilterInterface;
+use FFMpeg\Filters\Frames\FramesFilters;
+
+class Frames extends AbstractMediaType
+{
+    /**
+     * will extract a frame every second
+     */
+    const FRAMERATE_EVERY_SEC = '1/1';
+
+    /**
+     * will extract a frame every 2 seconds
+     */
+    const FRAMERATE_EVERY_2SEC = '1/2';
+
+    /**
+     * will extract a frame every 5 seconds
+     */
+    const FRAMERATE_EVERY_5SEC = '1/5';
+
+    /**
+     * will extract a frame every 10 seconds
+     */
+    const FRAMERATE_EVERY_10SEC = '1/10';
+
+    /**
+     * will extract a frame every 30 seconds
+     */
+    const FRAMERATE_EVERY_30SEC = '1/30';
+
+    /**
+     * will extract a frame every minute
+     */
+    const FRAMERATE_EVERY_60SEC = '1/60';
+
+    /**
+     * @var string
+     */
+    private $frameRate;
+
+    /**
+     * @var string
+     */
+    private $frameFileType = 'jpg';
+
+    /**
+     * @var Video
+     */
+    private $video;
+
+    /**
+     * @var array
+     */
+    private static $supportedFrameFileTypes = array('jpg', 'jpeg', 'png');
+
+    public function __construct(Video $video, FFMpegDriver $driver, FFProbe $ffprobe, $frameRate = self::FRAMERATE_EVERY_SEC)
+    {
+        parent::__construct($video->getPathfile(), $driver, $ffprobe);
+        $this->video = $video;
+        $this->frameRate = $frameRate;
+    }
+
+    /**
+     * @param string $frameFileType
+     * @return Frames
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setFrameFileType($frameFileType)
+    {
+        if (in_array($frameFileType, self::$supportedFrameFileTypes, true)) {
+            $this->frameFileType = $frameFileType;
+            return $this;
+        }
+
+        throw new InvalidArgumentException('Invalid frame file type, use: ' . implode(',', self::$supportedFrameFileTypes));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return FramesFilters
+     */
+    public function filters()
+    {
+        return new FramesFilters($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function addFilter(FramesFilterInterface $filter)
+    {
+        $this->filters->add($filter);
+
+        return $this;
+    }
+
+    /**
+     * Saves frames to the $destinationFolder
+     *
+     * @param string $destinationFolder
+     *
+     * @return self
+     *
+     * @throws RuntimeException
+     */
+    public function save($destinationFolder = __DIR__)
+    {
+        /**
+         * @see https://trac.ffmpeg.org/wiki/Create%20a%20thumbnail%20image%20every%20X%20seconds%20of%20the%20video
+         */
+
+        $destinationFolder = rtrim($destinationFolder, '/') . '/';
+        $commands = array('-y', '-i', $this->pathfile);
+        $duration = 0;
+
+        try {
+            // Get the duration of the video
+            foreach ($this->video->getStreams()->videos() as $stream) {
+                if ($stream->has('duration')) {
+                    $duration = $stream->get('duration');
+                }
+            }
+
+            // Get the number of frames per second we have to extract.
+            if (preg_match('/(\d+)(?:\s*)([\+\-\*\/])(?:\s*)(\d+)/', $this->frameRate, $matches) !== false) {
+                $operator = $matches[2];
+
+                if ($operator !== '/') {
+                    throw new InvalidArgumentException('The frame rate is not a proper division: ' . $this->frameRate);
+                }
+
+                $nbFramesPerSecond = $matches[1] / $matches[3];
+            }
+
+            // Set the number of digits to use in the exported filenames
+            $nbImages = ceil( $duration * $nbFramesPerSecond );
+
+            if ($nbImages < 100) {
+                $nbDigitsInFileNames = '02';
+            } elseif($nbImages < 1000) {
+                $nbDigitsInFileNames = '03';
+            } else {
+                $nbDigitsInFileNames = '06';
+            }
+
+            // Set the parameters
+            $commands[] = '-vf';
+            $commands[] = 'fps=' . $this->frameRate;
+            $commands[] = $destinationFolder . 'frame-%' . $nbDigitsInFileNames . 'd.' . $this->frameFileType;
+        } catch (RuntimeException $e) {
+            throw new RuntimeException('An error occured while extracting the frames: ' . $e->getMessage() . '. The code: ' . $e->getCode());
+        }
+
+        foreach ($this->filters as $filter) {
+            $commands = array_merge($commands, $filter->apply($this));
+        }
+
+        try {
+            $this->driver->command($commands);
+        } catch (ExecutionFailureException $e) {
+            $pattern = $destinationFolder . 'frame-*.' . $this->frameFileType;
+            foreach (glob($pattern) as $file) {
+                $this->cleanupTemporaryFile($file);
+            }
+            throw new RuntimeException('Unable to save frames', $e->getCode(), $e);
+        }
+
+        return $this;
+    }
+}

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -61,4 +61,15 @@ class Video extends AbstractVideo
     {
         return new Clip($this, $this->driver, $this->ffprobe, $start, $duration);
     }
+
+    /**
+     * Gets the frames at $frameRate.
+     *
+     * @param string $frameRate
+     * @return Frames
+     */
+    public function frames($frameRate = Frames::FRAMERATE_EVERY_SEC)
+    {
+        return new Frames($this, $this->driver, $this->ffprobe, $frameRate);
+    }
 }

--- a/tests/Functional/FramesExtractTest.php
+++ b/tests/Functional/FramesExtractTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\FFMpeg\Functional;
+
+
+use FFMpeg\Media\Frames;
+
+class FramesExtractTest extends FunctionalTestCase
+{
+    /**
+     * @param int $framesPerSecond
+     * @param int $expectedImages
+     *
+     * @dataProvider framesProvider
+     */
+    public function testFramesCount($framesPerSecond, $expectedImages)
+    {
+        $saveFolder = __DIR__ . '/output/';
+        $filenameTemplate = $saveFolder . 'frame-%02d.jpg';
+        $files = array();
+        for ($i=1; $i < $expectedImages + 1; $i++) {
+            $filename = sprintf($filenameTemplate, $i);
+            if (is_file($filename)) {
+                unlink($filename);
+            }
+            $files[] = $filename;
+        }
+
+        $ffmpeg = $this->getFFMpeg();
+        $video = $ffmpeg->open(__DIR__ . '/../files/Test.ogv');
+
+        $this->assertInstanceOf('FFMpeg\Media\Video', $video);
+
+        $frames = $video->frames($framesPerSecond);
+
+        $frames->save($saveFolder);
+        for ($i=1; $i < $expectedImages + 1; $i++) {
+            $filename = sprintf($filenameTemplate, $i);
+            $this->assertFileExists($filename);
+            unlink($filename);
+        }
+
+        // next frame was not fetched
+        $this->assertFileNotExists(sprintf($filenameTemplate, $i));
+    }
+
+    public function framesProvider()
+    {
+        $calls = array();
+
+        // video length is 00:00:29.53 and ffmpeg catches frame on second 0
+        $calls[] = array(Frames::FRAMERATE_EVERY_2SEC, 16);
+        $calls[] = array(Frames::FRAMERATE_EVERY_SEC, 30);
+
+        return $calls;
+    }
+}

--- a/tests/Unit/Media/FramesTest.php
+++ b/tests/Unit/Media/FramesTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Media;
+
+use FFMpeg\FFProbe\DataMapping\Stream;
+use FFMpeg\FFProbe\DataMapping\StreamCollection;
+use FFMpeg\Media\Frames;
+
+class FramesTest extends AbstractMediaTestCase
+{
+    public function testFiltersReturnFilters()
+    {
+        $driver = $this->getFFMpegDriverMock();
+        $ffprobe = $this->getFFProbeMock();
+
+        $frames = new Frames($this->getVideoMock(__FILE__), $driver, $ffprobe);
+        $this->assertInstanceOf('FFMpeg\Filters\Frames\FramesFilters', $frames->filters());
+    }
+
+    public function testAddFiltersAddsAFilter()
+    {
+        $driver = $this->getFFMpegDriverMock();
+        $ffprobe = $this->getFFProbeMock();
+
+        $filters = $this->getMockBuilder('FFMpeg\Filters\FiltersCollection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Frames\FramesFilterInterface')->getMock();
+
+        $filters->expects($this->once())
+            ->method('add')
+            ->with($filter);
+
+        $frames = new Frames($this->getVideoMock(__FILE__), $driver, $ffprobe);
+        $frames->setFiltersCollection($filters);
+        $frames->addFilter($filter);
+    }
+
+    /**
+     * @dataProvider provideSaveOptions
+     */
+    public function testSave($destination, $framerate, $duration, $fileType, $commands)
+    {
+        $driver = $this->getFFMpegDriverMock();
+        $ffprobe = $this->getFFProbeMock();
+
+        $streams = new StreamCollection(array(
+            new Stream(array(
+                'codec_type' => 'video',
+                'duration' => $duration,
+            ))
+        ));
+
+        $video = $this->getVideoMock(__FILE__);
+        $video->expects($this->once())
+            ->method('getStreams')
+            ->will($this->returnValue($streams));
+
+        $driver->expects($this->once())
+            ->method('command')
+            ->with($commands);
+
+        $frames = new Frames($video, $driver, $ffprobe, $framerate);
+        $frames->setFrameFileType($fileType);
+
+        $this->assertSame($frames, $frames->save($destination));
+    }
+
+    public function provideSaveOptions()
+    {
+        return array(
+            array(
+                '/some/destination',
+                Frames::FRAMERATE_EVERY_SEC,
+                100,
+                'jpg',
+                array(
+                    '-y',
+                    '-i', __FILE__,
+                    '-vf',
+                    'fps=' . Frames::FRAMERATE_EVERY_SEC,
+                    '/some/destination/frame-%03d.jpg'
+                ),
+            ),
+            array(
+                '/some/destination/',
+                Frames::FRAMERATE_EVERY_60SEC,
+                100,
+                'png',
+                array(
+                    '-y',
+                    '-i', __FILE__,
+                    '-vf',
+                    'fps=' . Frames::FRAMERATE_EVERY_60SEC,
+                    '/some/destination/frame-%02d.png'
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | yes
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Allowing the user to extract frames without encoding a file

#### Why?

If you need to split a video in frames and you dont want to encode the video also.

#### Example Usage

#### BC Breaks/Deprecations
ExtractMultipleFrames Filter is deprecated here, but i am not sure if this is needed.
Can't we keep both options ? allow working with the filter and encoding and work without the filter and without encoding
