### PR TITLE
Add stream method to identify a video's rotation.

### DIFF
--- a/src/FFMpeg/FFProbe/DataMapping/Stream.php
+++ b/src/FFMpeg/FFProbe/DataMapping/Stream.php
@@ -82,6 +82,24 @@ class Stream extends AbstractData
     }
 
     /**
+     * Returns the rotation of the video stream, in degrees.
+     * Use this to determine if the dimensions are rotated.
+     *
+     * @return Integer
+     *
+     * @throws LogicException   In case the stream is not a video stream.
+     */
+    public function getRotation()
+    {
+      if (!$this->isVideo()) {
+        throw new LogicException('Rotation can only be retrieved from video streams.');
+      }
+      $tags = $this->get('tags');
+      if(empty($tags['rotate'])) return 0;
+      return intval($tags['rotate']);
+    }
+
+    /**
      * Extracts a ratio from a string in a \d+:\d+ format given a key name.
      *
      * @param  Stream     $stream The stream where to look for the ratio.


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | no
| Related issues/PRs | #117 #199 
| License            | MIT

#### What's in this PR?

Add a stream method to easily identify the rotation of a video.

#### Why?

There seems to be a common confusion regarding the dimensions of a video that have been rotated. FFProbe can report the width and height as the reverse of what the video appears to have. iPhones create portrait video that exhibit this issue, for example. But by inspecting the rotation of a video, this issue can be accounted for. By providing a getRotation method alongside the getDimensions method, it will be easier for users of this library to discover the reason for their confusion.

Here are some examples of people exhibiting this confusion, sometimes with this library, sometimes with FFProbe vanilla:
https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues/117
https://forums.creativecow.net/docs/forums/post.php?forumid=291&postid=888&univpostid=888&pview=t
https://stackoverflow.com/questions/53339787/ffmpeg-get-orientation-inverted
https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues/199
https://stackoverflow.com/questions/13093295/how-can-i-determine-video-rotation-orientation-in-php-ffmpeg-phonegap

Here's a help page from this library that discusses the issue. This new method is self-documenting code that would assist users who go down the same rabbit hole that I did:
https://github.com/PHP-FFMpeg/PHP-FFMpeg/wiki/How-to-rotate-video-based-on-smartphone-rotate-meta-tag

#### Example Usage

```php
$stream = FFProbe::create()
        ->streams($video_filepath)
        ->videos()
        ->first();
$rotation = $stream->getRotation();
$dims = $stream->getDimensions();

// Now we can reverse dimensions
if((90 === $rotation) || (-90 === $rotation)) $dims = new Dimension($dims->getHeight(), $dims->getWidth());
```
