### PR TITLE
Add getter and setter for global FFmpeg options

### DIFF
--- a/src/FFMpeg/Media/AbstractVideo.php
+++ b/src/FFMpeg/Media/AbstractVideo.php
@@ -25,6 +25,9 @@ use FFMpeg\Filters\Video\ClipFilter;
 abstract class AbstractVideo extends Audio
 {
 
+    /** @var string */
+    protected $options;
+
     /**
      * FileSystem Manager instance
      * @var Manager
@@ -124,6 +127,29 @@ abstract class AbstractVideo extends Audio
         $this->fs->clean($this->fsId);
 
         return $finalCommands;
+    }
+
+    /**
+     * Gets global FFmpeg options
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Sets global FFmpeg options
+     *
+     * @param array $options
+     * @return Video
+     */
+    public function setOptions($options = array())
+    {
+        $this->options = array_reverse($options);
+
+        return $this;
     }
 
     /**
@@ -287,6 +313,16 @@ abstract class AbstractVideo extends Audio
      */
     protected function basePartOfCommand()
     {
-        return array('-y', '-i', $this->pathfile);
+        $base = array('-y', '-i', $this->pathfile);
+
+        if(is_array($this->options))
+        {
+            foreach ($this->options as $option)
+            {
+                array_unshift($base, $option);
+            }
+        }
+        return $base;
     }
 }
+


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

This PR adds functions to get and set global FFmpeg options. 

#### Why?

These functions are required to set options before the input file argument, for example -hwaccel vaapi for GPU-based encoding.

#### Example Usage

```php
$video->setOptions(array(
       '-hwaccel', 'vaapi',
       '-hwaccel_output_format' , 'vaapi',
       '-hwaccel_device' , '/dev/dri/renderD128'
));
```
#### To Do

- [ ] Create tests
