### PR TITLE
Fix PhpUnit tests for newer php version 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 composer.phar
 composer.lock
 phpunit.xml
+.phpunit.result.cache
 sami.phar
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ composer.phar
 composer.lock
 phpunit.xml
 .phpunit.result.cache
+/tests/Functional/output/output-*
 sami.phar
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ phpunit.xml
 /tests/Functional/output/output-*
 sami.phar
 .idea/
+/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,14 @@ matrix:
   include:
     - php: 5.4
       env:
+        - PHPUNIT_VERSION=4
         - COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.4
+      env:
+        - PHPUNIT_VERSION=4
     - php: 5.5
+      env:
+        - PHPUNIT_VERSION=4
     - php: 5.6
     - php: 7.0
     - php: 7.1
@@ -30,11 +35,26 @@ before_install:
   - sudo add-apt-repository ppa:mc3man/trusty-media -y
   - sudo apt-get update -q
   - composer self-update
-  - if [ "$COMPOSER_FLAGS" == "--prefer-lowest" ]; then composer require "roave/security-advisories" dev-master --no-update; fi;
+  - echo "$PHPUNIT_VERSION"
+  - |
+    if [ "$PHPUNIT_VERSION" ]; then
+      composer remove symfony/phpunit-bridge --dev
+      wget -O phpunit "https://phar.phpunit.de/phpunit-$PHPUNIT_VERSION.phar"
+      chmod +x phpunit
+    fi;
+  - |
+    if [ "$COMPOSER_FLAGS" == "--prefer-lowest" ]; then
+      composer require "roave/security-advisories" dev-master --no-update
+    fi;
 
 install:
   - sudo apt-get install -y ffmpeg
   - composer update --prefer-dist $COMPOSER_FLAGS
 
 script:
-  - vendor/bin/phpunit --verbose
+  - |
+    if [ "$PHPUNIT_VERSION" ]; then
+      ./phpunit --verbose
+    else
+      ./vendor/bin/simple-phpunit --verbose
+    fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,19 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.cache
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
-
 matrix:
   include:
     - php: 5.4
-      env: COMPOSER_FLAGS="--prefer-lowest"
+      env:
+        - COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
 
 before_install:
   - sudo add-apt-repository ppa:mc3man/trusty-media -y
@@ -38,4 +37,4 @@ install:
   - composer update --prefer-dist $COMPOSER_FLAGS
 
 script:
-  - vendor/bin/simple-phpunit --verbose
+  - vendor/bin/phpunit --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 matrix:
   include:
@@ -37,4 +38,4 @@ install:
   - composer update --prefer-dist $COMPOSER_FLAGS
 
 script:
-  - vendor/bin/phpunit --verbose
+  - vendor/bin/simple-phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "sami/sami": "~1.0",
         "silex/silex": "~1.0",
-        "symfony/phpunit-bridge": "^4.2.12 || ^5.0.4"
+        "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "sami/sami": "~1.0",
         "silex/silex": "~1.0",
-        "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/phpunit-bridge": "^5.0.4"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "sami/sami": "~1.0",
         "silex/silex": "~1.0",
-        "symfony/phpunit-bridge": "^5.0.4"
+        "symfony/phpunit-bridge": "^4.2.12 || ^5.0.4"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "sami/sami": "~1.0",
         "silex/silex": "~1.0",
-        "phpunit/phpunit": "^4.8.36"
+        "symfony/phpunit-bridge": "^5.0.4"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,10 +7,13 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="false"
          bootstrap="tests/bootstrap.php"
 >
+    <php>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="true"/>
+    </php>
+
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>
@@ -21,10 +24,9 @@
     </testsuites>
 
     <filter>
-      <blacklist>
-        <directory>vendor</directory>
-        <directory>tests</directory>
-      </blacklist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+        </whitelist>
     </filter>
 </phpunit>
 

--- a/src/FFMpeg/Media/Concat.php
+++ b/src/FFMpeg/Media/Concat.php
@@ -94,7 +94,7 @@ class Concat extends AbstractMediaType
         $fileStream = @fopen($sourcesFile, 'w');
 
         if($fileStream === false) {
-            throw new ExecutionFailureException('Cannot open the temporary file.');
+            throw new RuntimeException('Cannot open the temporary file.');
         }
 
         $count_videos = 0;

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\FFMpeg;
+
+use PHPUnit\Framework\TestCase;
+
+class BaseTestCase extends TestCase
+{
+    public function assertScalar($value, $message = '')
+    {
+        $this->assertTrue(is_scalar($value), $message);
+    }
+
+    /**
+     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
+     */
+    public function assertIsArray($value, $message = '')
+    {
+        $this->assertTrue(is_array($value), $message);
+    }
+
+    /**
+     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
+     */
+    public function assertIsInt($value, $message = '')
+    {
+        $this->assertTrue(is_int($value), $message);
+    }
+
+    /**
+     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
+     */
+    public function assertIsBool($value, $message = '')
+    {
+        $this->assertTrue(is_bool($value), $message);
+    }
+
+    /**
+     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
+     */
+    public function assertIsString($value, $message = '')
+    {
+        $this->assertTrue(is_string($value), $message);
+    }
+
+    /**
+     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
+     */
+    public function expectException($exception)
+    {
+        // PHPUnt BC Layer
+        if (method_exists(get_parent_class(), 'expectException')) {
+            parent::expectException($exception);
+
+            return;
+        }
+
+        $this->setExpectedException($exception);
+    }
+}

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -4,57 +4,49 @@ namespace Tests\FFMpeg;
 
 use PHPUnit\Framework\TestCase;
 
-class BaseTestCase extends TestCase
-{
-    public function assertScalar($value, $message = '')
+/**
+ * This is a BC Layer to support phpunit 4.8 needed for php <= 5.5.
+ */
+if (class_exists('PHPUnit_Runner_Version')
+    && version_compare(\PHPUnit_Runner_Version::id(), '5', '<')) {
+    class BaseTestCase extends TestCase
     {
-        $this->assertTrue(is_scalar($value), $message);
-    }
-
-    /**
-     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
-     */
-    public function assertIsArray($value, $message = '')
-    {
-        $this->assertTrue(is_array($value), $message);
-    }
-
-    /**
-     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
-     */
-    public function assertIsInt($value, $message = '')
-    {
-        $this->assertTrue(is_int($value), $message);
-    }
-
-    /**
-     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
-     */
-    public function assertIsBool($value, $message = '')
-    {
-        $this->assertTrue(is_bool($value), $message);
-    }
-
-    /**
-     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
-     */
-    public function assertIsString($value, $message = '')
-    {
-        $this->assertTrue(is_string($value), $message);
-    }
-
-    /**
-     * Can be removed when phpunit 4.8 (<= needed for php 5.5) support is removed.
-     */
-    public function expectException($exception)
-    {
-        // PHPUnt BC Layer
-        if (method_exists(get_parent_class(), 'expectException')) {
-            parent::expectException($exception);
-
-            return;
+        public static function assertScalar($value, $message = '')
+        {
+            self::assertTrue(is_scalar($value), $message);
         }
 
-        $this->setExpectedException($exception);
+        public static function assertIsArray($value, $message = '')
+        {
+            self::assertTrue(is_array($value), $message);
+        }
+
+        public static function assertIsInt($value, $message = '')
+        {
+            self::assertTrue(is_int($value), $message);
+        }
+
+        public static function assertIsBool($value, $message = '')
+        {
+            self::assertTrue(is_bool($value), $message);
+        }
+
+        public static function assertIsString($value, $message = '')
+        {
+            self::assertTrue(is_string($value), $message);
+        }
+
+        public function expectException($exception, $message = null)
+        {
+            $this->setExpectedException($exception, $message);
+        }
+    }
+} else {
+    class BaseTestCase extends TestCase
+    {
+        public function assertScalar($value, $message = '')
+        {
+            $this->assertTrue(is_scalar($value), $message);
+        }
     }
 }

--- a/tests/Functional/FFProbeTest.php
+++ b/tests/Functional/FFProbeTest.php
@@ -25,11 +25,10 @@ class FFProbeTest extends FunctionalTestCase
         $this->assertFalse($ffprobe->isValid(__DIR__ . '/../files/WrongFile.mp4'));
     }
 
-    /**
-     * @expectedException FFMpeg\Exception\RuntimeException
-     */
     public function testProbeOnNonExistantFile()
     {
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
+
         $ffprobe = FFProbe::create();
         $ffprobe->streams('/path/to/no/file');
     }

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -3,9 +3,9 @@
 namespace Tests\FFMpeg\Functional;
 
 use FFMpeg\FFMpeg;
-use PHPUnit\Framework\TestCase;
+use Tests\FFMpeg\BaseTestCase;
 
-abstract class FunctionalTestCase extends TestCase
+abstract class FunctionalTestCase extends BaseTestCase
 {
     /**
      * @return FFMpeg

--- a/tests/Functional/VideoTranscodeTest.php
+++ b/tests/Functional/VideoTranscodeTest.php
@@ -71,10 +71,10 @@ class VideoTranscodeTest extends FunctionalTestCase
     }
 
     /**
-     * @expectedException \FFMpeg\Exception\RuntimeException
      */
     public function testTranscodeInvalidFile()
     {
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $ffmpeg = $this->getFFMpeg();
         $ffmpeg->open(__DIR__ . '/../files/UnknownFileTest.ogv');
     }
@@ -84,7 +84,7 @@ class VideoTranscodeTest extends FunctionalTestCase
         $ffmpeg = $this->getFFMpeg();
         $video = new Video(__DIR__ . '/../files/UnknownFileTest.ogv', $ffmpeg->getFFMpegDriver(), $ffmpeg->getFFProbe());
 
-        $this->setExpectedException('FFMpeg\Exception\RuntimeException');
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $video->save(new X264('aac'), __DIR__ . '/output/output-x264.mp4');
     }
 

--- a/tests/Unit/Coordinate/DimensionTest.php
+++ b/tests/Unit/Coordinate/DimensionTest.php
@@ -9,10 +9,10 @@ class DimensionTest extends TestCase
 {
     /**
      * @dataProvider provideInvalidDimensions
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testInvalidDimensions($width, $height)
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         new Dimension($width, $height);
     }
 

--- a/tests/Unit/Coordinate/FrameRateTest.php
+++ b/tests/Unit/Coordinate/FrameRateTest.php
@@ -15,10 +15,10 @@ class FrameRateTest extends TestCase
 
     /**
      * @dataProvider provideInvalidFrameRates
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testInvalidFrameRate($value)
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         new FrameRate($value);
     }
 

--- a/tests/Unit/Coordinate/TimeCodeTest.php
+++ b/tests/Unit/Coordinate/TimeCodeTest.php
@@ -28,8 +28,6 @@ class TimeCodeTest extends TestCase
         );
     }
 
-    /**
-     */
     public function testFromInvalidString()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');

--- a/tests/Unit/Coordinate/TimeCodeTest.php
+++ b/tests/Unit/Coordinate/TimeCodeTest.php
@@ -29,10 +29,10 @@ class TimeCodeTest extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testFromInvalidString()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         TimeCode::fromString('lalali lala');
     }
 

--- a/tests/Unit/Driver/FFMpegDriverTest.php
+++ b/tests/Unit/Driver/FFMpegDriverTest.php
@@ -42,10 +42,10 @@ class FFMpegDriverTest extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\ExecutableNotFoundException
      */
     public function testCreateFailureThrowsAnException()
     {
+        $this->expectException('\FFMpeg\Exception\ExecutableNotFoundException');
         FFMpegDriver::create($this->getLoggerMock(), array('ffmpeg.binaries' => '/path/to/nowhere'));
     }
 }

--- a/tests/Unit/Driver/FFMpegDriverTest.php
+++ b/tests/Unit/Driver/FFMpegDriverTest.php
@@ -41,8 +41,6 @@ class FFMpegDriverTest extends TestCase
         $this->assertEquals($conf, $ffmpeg->getConfiguration());
     }
 
-    /**
-     */
     public function testCreateFailureThrowsAnException()
     {
         $this->expectException('\FFMpeg\Exception\ExecutableNotFoundException');

--- a/tests/Unit/Driver/FFProbeDriverTest.php
+++ b/tests/Unit/Driver/FFProbeDriverTest.php
@@ -41,8 +41,6 @@ class FFProbeDriverTest extends TestCase
         $this->assertEquals($conf, $ffprobe->getConfiguration());
     }
 
-    /**
-     */
     public function testCreateFailureThrowsAnException()
     {
         $this->expectException('\FFMpeg\Exception\ExecutableNotFoundException');

--- a/tests/Unit/Driver/FFProbeDriverTest.php
+++ b/tests/Unit/Driver/FFProbeDriverTest.php
@@ -42,10 +42,10 @@ class FFProbeDriverTest extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\ExecutableNotFoundException
      */
     public function testCreateFailureThrowsAnException()
     {
+        $this->expectException('\FFMpeg\Exception\ExecutableNotFoundException');
         FFProbeDriver::create(array('ffprobe.binaries' => '/path/to/nowhere'));
     }
 }

--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -51,7 +51,7 @@ class FFMpegServiceProviderTest extends BaseTestCase
             )
         ));
 
-        $this->setExpectedException('FFMpeg\Exception\ExecutableNotFoundException', 'Unable to load FFMpeg');
+        $this->expectException('\FFMpeg\Exception\ExecutableNotFoundException', 'Unable to load FFMpeg');
         $app['ffmpeg'];
     }
 
@@ -64,7 +64,7 @@ class FFMpegServiceProviderTest extends BaseTestCase
             )
         ));
 
-        $this->setExpectedException('FFMpeg\Exception\ExecutableNotFoundException', 'Unable to load FFProbe');
+        $this->expectException('\FFMpeg\Exception\ExecutableNotFoundException', 'Unable to load FFProbe');
         $app['ffmpeg.ffprobe'];
     }
 }

--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -4,9 +4,8 @@ namespace Tests\FFMpeg\Unit;
 
 use FFMpeg\FFMpegServiceProvider;
 use Silex\Application;
-use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class FFMpegServiceProviderTest extends BaseTestCase
+class FFMpegServiceProviderTest extends TestCase
 {
     public function testWithConfig()
     {

--- a/tests/Unit/FFMpegTest.php
+++ b/tests/Unit/FFMpegTest.php
@@ -8,12 +8,12 @@ use FFMpeg\FFProbe\DataMapping\Stream;
 
 class FFMpegTest extends TestCase
 {
-    /**
-     * @expectedExceptionMessage Unable to probe "/path/to/unknown/file".
-     */
     public function testOpenInvalid()
     {
-        $this->expectException('\FFMpeg\Exception\RuntimeException');
+        $this->expectException(
+            '\FFMpeg\Exception\RuntimeException',
+            'Unable to probe "/path/to/unknown/file"'
+        );
         $ffmpeg = new FFMpeg($this->getFFMpegDriverMock(), $this->getFFProbeMock());
         $ffmpeg->open('/path/to/unknown/file');
     }
@@ -57,8 +57,6 @@ class FFMpegTest extends TestCase
         $this->assertInstanceOf('FFMpeg\Media\Video', $ffmpeg->open(__FILE__));
     }
 
-    /**
-     */
     public function testOpenUnknown()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');

--- a/tests/Unit/FFMpegTest.php
+++ b/tests/Unit/FFMpegTest.php
@@ -9,11 +9,11 @@ use FFMpeg\FFProbe\DataMapping\Stream;
 class FFMpegTest extends TestCase
 {
     /**
-     * @expectedException \FFMpeg\Exception\RuntimeException
      * @expectedExceptionMessage Unable to probe "/path/to/unknown/file".
      */
     public function testOpenInvalid()
     {
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $ffmpeg = new FFMpeg($this->getFFMpegDriverMock(), $this->getFFProbeMock());
         $ffmpeg->open('/path/to/unknown/file');
     }
@@ -58,10 +58,10 @@ class FFMpegTest extends TestCase
     }
 
     /**
-     * @expectedException \FFMpeg\Exception\InvalidArgumentException
      */
     public function testOpenUnknown()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $ffprobe = $this->getFFProbeMock();
         $ffprobe->expects($this->once())
             ->method('streams')

--- a/tests/Unit/FFProbe/DataMapping/StreamTest.php
+++ b/tests/Unit/FFProbe/DataMapping/StreamTest.php
@@ -43,11 +43,11 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\LogicException
      * @expectedExceptionMessage Dimensions can only be retrieved from video streams.
      */
     public function testGetDimensionsFromAudio()
     {
+        $this->expectException('\FFMpeg\Exception\LogicException');
         $stream = new Stream(array('codec_type' => 'audio'));
         $stream->getDimensions();
     }
@@ -60,11 +60,11 @@ class StreamTest extends TestCase
 
     /**
      * @dataProvider provideInvalidPropertiesForDimensionsExtraction
-     * @expectedException FFMpeg\Exception\RuntimeException
      * @expectedExceptionMessage Unable to extract dimensions.
      */
     public function testUnableToGetDimensionsFromVideo($properties)
     {
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $stream = new Stream(array('codec_type' => 'video', 'width' => 960));
         $stream->getDimensions();
     }

--- a/tests/Unit/FFProbe/DataMapping/StreamTest.php
+++ b/tests/Unit/FFProbe/DataMapping/StreamTest.php
@@ -42,12 +42,12 @@ class StreamTest extends TestCase
         );
     }
 
-    /**
-     * @expectedExceptionMessage Dimensions can only be retrieved from video streams.
-     */
     public function testGetDimensionsFromAudio()
     {
-        $this->expectException('\FFMpeg\Exception\LogicException');
+        $this->expectException(
+            '\FFMpeg\Exception\LogicException',
+            'Dimensions can only be retrieved from video streams.'
+        );
         $stream = new Stream(array('codec_type' => 'audio'));
         $stream->getDimensions();
     }
@@ -60,11 +60,13 @@ class StreamTest extends TestCase
 
     /**
      * @dataProvider provideInvalidPropertiesForDimensionsExtraction
-     * @expectedExceptionMessage Unable to extract dimensions.
      */
     public function testUnableToGetDimensionsFromVideo($properties)
     {
-        $this->expectException('\FFMpeg\Exception\RuntimeException');
+        $this->expectException(
+            '\FFMpeg\Exception\RuntimeException',
+            'Unable to extract dimensions.'
+        );
         $stream = new Stream(array('codec_type' => 'video', 'width' => 960));
         $stream->getDimensions();
     }

--- a/tests/Unit/FFProbe/MapperTest.php
+++ b/tests/Unit/FFProbe/MapperTest.php
@@ -21,10 +21,10 @@ class MapperTest extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testMapInvalidArgument()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $mapper = new Mapper();
         $mapper->map('cool type', 'data');
     }

--- a/tests/Unit/FFProbe/MapperTest.php
+++ b/tests/Unit/FFProbe/MapperTest.php
@@ -20,8 +20,6 @@ class MapperTest extends TestCase
         $this->assertEquals($expected, $mapper->map($type, $data));
     }
 
-    /**
-     */
     public function testMapInvalidArgument()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');

--- a/tests/Unit/FFProbe/OptionsTesterTest.php
+++ b/tests/Unit/FFProbe/OptionsTesterTest.php
@@ -3,24 +3,25 @@
 namespace Tests\FFMpeg\Unit\FFProbe;
 
 use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use FFMpeg\Exception\RuntimeException;
 use Tests\FFMpeg\Unit\TestCase;
 use FFMpeg\FFProbe\OptionsTester;
 
 class OptionsTesterTest extends TestCase
 {
     /**
-     * @expectedException FFMpeg\Exception\RuntimeException
      * @expectedExceptionMessage Your FFProbe version is too old and does not support `-help` option, please upgrade.
      */
     public function testHasOptionWithOldFFProbe()
     {
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $cache = $this->getCacheMock();
 
         $ffprobe = $this->getFFProbeDriverMock();
         $ffprobe->expects($this->once())
             ->method('command')
             ->with(array('-help', '-loglevel', 'quiet'))
-            ->will($this->throwException(new ExecutionFailureException('Failed to execute')));
+            ->will($this->throwException(new RuntimeException('Failed to execute')));
 
         $tester = new OptionsTester($ffprobe, $cache);
         $tester->has('-print_format');

--- a/tests/Unit/FFProbe/OptionsTesterTest.php
+++ b/tests/Unit/FFProbe/OptionsTesterTest.php
@@ -2,26 +2,28 @@
 
 namespace Tests\FFMpeg\Unit\FFProbe;
 
-use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
-use FFMpeg\Exception\RuntimeException;
 use Tests\FFMpeg\Unit\TestCase;
 use FFMpeg\FFProbe\OptionsTester;
 
 class OptionsTesterTest extends TestCase
 {
-    /**
-     * @expectedExceptionMessage Your FFProbe version is too old and does not support `-help` option, please upgrade.
-     */
     public function testHasOptionWithOldFFProbe()
     {
-        $this->expectException('\FFMpeg\Exception\RuntimeException');
+        $this->expectException(
+            '\FFMpeg\Exception\RuntimeException',
+            'Your FFProbe version is too old and does not support `-help` option, please upgrade.'
+        );
         $cache = $this->getCacheMock();
+
+        $executionFailerExceptionMock = $this->getMockBuilder('Alchemy\BinaryDriver\Exception\ExecutionFailureException')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $ffprobe = $this->getFFProbeDriverMock();
         $ffprobe->expects($this->once())
             ->method('command')
             ->with(array('-help', '-loglevel', 'quiet'))
-            ->will($this->throwException(new RuntimeException('Failed to execute')));
+            ->will($this->throwException($executionFailerExceptionMock));
 
         $tester = new OptionsTester($ffprobe, $cache);
         $tester->has('-print_format');

--- a/tests/Unit/FFProbe/OutputParserTest.php
+++ b/tests/Unit/FFProbe/OutputParserTest.php
@@ -17,8 +17,6 @@ class OutputParserTest extends TestCase
         $this->assertEquals($expectedOutput, $parser->parse($type, $data));
     }
 
-    /**
-     */
     public function testParseWithInvalidArgument()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');

--- a/tests/Unit/FFProbe/OutputParserTest.php
+++ b/tests/Unit/FFProbe/OutputParserTest.php
@@ -18,10 +18,10 @@ class OutputParserTest extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testParseWithInvalidArgument()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $parser = new OutputParser();
         $parser->parse('comme ca', 'data');
     }

--- a/tests/Unit/FFProbeTest.php
+++ b/tests/Unit/FFProbeTest.php
@@ -236,11 +236,11 @@ class FFProbeTest extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\RuntimeException
      * @dataProvider provideProbeMethod
      */
     public function testProbeWithoutShowStreamsAvailable($method)
     {
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $pathfile = __FILE__;
 
         $ffprobe = new FFProbe($this->getFFProbeDriverMock(), $this->getCacheMock());

--- a/tests/Unit/Filters/Audio/AudioClipTest.php
+++ b/tests/Unit/Filters/Audio/AudioClipTest.php
@@ -18,7 +18,7 @@ class AudioClipTest extends TestCase {
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
         }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filters = new AudioFilters($audio);
 
@@ -36,7 +36,7 @@ class AudioClipTest extends TestCase {
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
         }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filters = new AudioFilters($audio);
 

--- a/tests/Unit/Filters/Audio/AudioMetadataTest.php
+++ b/tests/Unit/Filters/Audio/AudioMetadataTest.php
@@ -18,7 +18,7 @@ class AudioMetadataTest extends TestCase
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
             }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filters = new AudioFilters($audio);
         $filters->addMetadata(array('title' => "Hello World"));
@@ -36,7 +36,7 @@ class AudioMetadataTest extends TestCase
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
             }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filters = new AudioFilters($audio);
         $filters->addMetadata(array('genre' => 'Some Genre', 'artwork' => "/path/to/file.jpg"));
@@ -55,7 +55,7 @@ class AudioMetadataTest extends TestCase
             ->will($this->returnCallback(function ($filter) use (&$capturedFilter) {
                 $capturedFilter = $filter;
             }));
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filters = new AudioFilters($audio);
         $filters->addMetadata();

--- a/tests/Unit/Filters/Audio/AudioResamplableFilterTest.php
+++ b/tests/Unit/Filters/Audio/AudioResamplableFilterTest.php
@@ -16,7 +16,7 @@ class AudioResamplableFilterTest extends TestCase
     public function testApply()
     {
         $audio = $this->getAudioMock();
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filter = new AudioResamplableFilter(500);
         $this->assertEquals(array('-ac', 2, '-ar', 500), $filter->apply($audio, $format));

--- a/tests/Unit/Filters/Audio/CustomFilterTest.php
+++ b/tests/Unit/Filters/Audio/CustomFilterTest.php
@@ -12,7 +12,7 @@ class CustomFilterTest extends TestCase
     public function testApplyCustomFilter()
     {
         $audio = $this->getAudioMock();
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filter = new CustomFilter('whatever i put would end up as a filter');
         $this->assertEquals(array('-af', 'whatever i put would end up as a filter'), $filter->apply($audio, $format));

--- a/tests/Unit/Filters/FiltersCollectionTest.php
+++ b/tests/Unit/Filters/FiltersCollectionTest.php
@@ -13,18 +13,18 @@ class FiltersCollectionTest extends TestCase
         $coll = new FiltersCollection();
         $this->assertCount(0, $coll);
 
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
+        $coll->add($this->getMockBuilder('FFMpeg\Filters\FilterInterface')->getMock());
         $this->assertCount(1, $coll);
 
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
+        $coll->add($this->getMockBuilder('FFMpeg\Filters\FilterInterface')->getMock());
         $this->assertCount(2, $coll);
     }
 
     public function testIterator()
     {
         $coll = new FiltersCollection();
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
-        $coll->add($this->getMock('FFMpeg\Filters\FilterInterface'));
+        $coll->add($this->getMockBuilder('FFMpeg\Filters\FilterInterface')->getMock());
+        $coll->add($this->getMockBuilder('FFMpeg\Filters\FilterInterface')->getMock());
 
         $this->assertInstanceOf('\ArrayIterator', $coll->getIterator());
         $this->assertCount(2, $coll->getIterator());
@@ -51,7 +51,7 @@ class FiltersCollectionTest extends TestCase
 
         $data = array();
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         foreach ($coll as $filter) {
             $data = array_merge($data, $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/CropFilterTest.php
+++ b/tests/Unit/Filters/Video/CropFilterTest.php
@@ -22,7 +22,7 @@ class CropFilterTest extends TestCase
             ->method('getStreams')
             ->will($this->returnValue($streams));
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         $dimension = new Dimension(200, 150);
         $point = new Point(25, 35);

--- a/tests/Unit/Filters/Video/CustomFilterTest.php
+++ b/tests/Unit/Filters/Video/CustomFilterTest.php
@@ -12,7 +12,7 @@ class CustomFilterTest extends TestCase
     public function testApplyCustomFilter()
     {
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         $filter = new CustomFilter('whatever i put would end up as a filter');
         $this->assertEquals(array('-vf', 'whatever i put would end up as a filter'), $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -17,7 +17,7 @@ class ExtractMultipleFramesFilterTest extends TestCase
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('getModulus')
             ->will($this->returnValue($modulus));

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -64,8 +64,6 @@ class ExtractMultipleFramesFilterTest extends TestCase
         );
     }
 
-    /**
-     */
     public function testInvalidFrameFileType() {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $filter = new ExtractMultipleFramesFilter('1/1', '/');

--- a/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
+++ b/tests/Unit/Filters/Video/ExtractMultipleFramesFilterTest.php
@@ -65,9 +65,9 @@ class ExtractMultipleFramesFilterTest extends TestCase
     }
 
     /**
-     * @expectedException \FFMpeg\Exception\InvalidArgumentException
      */
     public function testInvalidFrameFileType() {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $filter = new ExtractMultipleFramesFilter('1/1', '/');
         $filter->setFrameFileType('webm');
     }

--- a/tests/Unit/Filters/Video/FrameRateFilterTest.php
+++ b/tests/Unit/Filters/Video/FrameRateFilterTest.php
@@ -14,7 +14,7 @@ class FrameRateFilterTest extends TestCase
         $gop = 42;
 
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('supportBFrames')
             ->will($this->returnValue(true));
@@ -31,7 +31,7 @@ class FrameRateFilterTest extends TestCase
         $gop = 42;
 
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('supportBFrames')
             ->will($this->returnValue(false));

--- a/tests/Unit/Filters/Video/PadFilterTest.php
+++ b/tests/Unit/Filters/Video/PadFilterTest.php
@@ -18,7 +18,7 @@ class PadFilterTest extends TestCase
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         $streams = new StreamCollection(array(
             new Stream(array(

--- a/tests/Unit/Filters/Video/ResizeFilterTest.php
+++ b/tests/Unit/Filters/Video/ResizeFilterTest.php
@@ -18,7 +18,7 @@ class ResizeFilterTest extends TestCase
         $video = $this->getVideoMock();
         $pathfile = '/path/to/file'.mt_rand();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('getModulus')
             ->will($this->returnValue($modulus));

--- a/tests/Unit/Filters/Video/RotateFilterTest.php
+++ b/tests/Unit/Filters/Video/RotateFilterTest.php
@@ -22,7 +22,7 @@ class RotateFilterTest extends TestCase
             ->method('getStreams')
             ->will($this->returnValue($streams));
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         $filter = new RotateFilter($value);
         $this->assertEquals(array('-vf', $value, '-metadata:s:v:0', 'rotate=0'), $filter->apply($video, $format));
@@ -48,7 +48,7 @@ class RotateFilterTest extends TestCase
         $video->expects($this->never())
             ->method('getStreams');
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         $filter = new RotateFilter($value);
         $this->assertEquals(array('-vf', $value, '-metadata:s:v:0', 'rotate=0'), $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/RotateFilterTest.php
+++ b/tests/Unit/Filters/Video/RotateFilterTest.php
@@ -61,12 +61,12 @@ class RotateFilterTest extends TestCase
         );
     }
 
-    /**
-     * @expectedExceptionMessage Invalid angle value.
-     */
     public function testApplyInvalidAngle()
     {
-        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
+        $this->expectException(
+            '\FFMpeg\Exception\InvalidArgumentException',
+            'Invalid angle value.'
+        );
         new RotateFilter('90');
     }
 }

--- a/tests/Unit/Filters/Video/RotateFilterTest.php
+++ b/tests/Unit/Filters/Video/RotateFilterTest.php
@@ -62,11 +62,11 @@ class RotateFilterTest extends TestCase
     }
 
     /**
-     * @expectedException \FFMpeg\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid angle value.
      */
     public function testApplyInvalidAngle()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         new RotateFilter('90');
     }
 }

--- a/tests/Unit/Filters/Video/SynchronizeFilterTest.php
+++ b/tests/Unit/Filters/Video/SynchronizeFilterTest.php
@@ -10,7 +10,7 @@ class SynchronizeFilterTest extends TestCase
     public function testApply()
     {
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         $filter = new SynchronizeFilter();
         $this->assertEquals(array('-async', '1', '-metadata:s:v:0', 'start_time=0'), $filter->apply($video, $format));

--- a/tests/Unit/Filters/Video/WatermarkFilterTest.php
+++ b/tests/Unit/Filters/Video/WatermarkFilterTest.php
@@ -17,7 +17,7 @@ class WatermarkFilterTest extends TestCase
 
         $video = $this->getVideoMock();
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         $filter = new WatermarkFilter(__DIR__ . '/../../../files/watermark.png');
         $this->assertEquals(array('-vf', 'movie='.__DIR__ .'/../../../files/watermark.png [watermark]; [in][watermark] overlay=0:0 [out]'), $filter->apply($video, $format));
@@ -30,7 +30,7 @@ class WatermarkFilterTest extends TestCase
     public function testDifferentCoordinaates()
     {
         $video = $this->getVideoMock();
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
 
         // test position absolute
         $filter = new WatermarkFilter(__DIR__ . '/../../../files/watermark.png', array(

--- a/tests/Unit/Format/Audio/AudioTestCase.php
+++ b/tests/Unit/Format/Audio/AudioTestCase.php
@@ -101,7 +101,7 @@ abstract class AudioTestCase extends TestCase
 
     public function testCreateProgressListener()
     {
-        $media = $this->getMock('FFMpeg\Media\MediaTypeInterface');
+        $media = $this->getMockBuilder('FFMpeg\Media\MediaTypeInterface')->getMock();
         $media->expects($this->any())
             ->method('getPathfile')
             ->will($this->returnValue(__FILE__));

--- a/tests/Unit/Format/Audio/AudioTestCase.php
+++ b/tests/Unit/Format/Audio/AudioTestCase.php
@@ -34,8 +34,6 @@ abstract class AudioTestCase extends TestCase
         }
     }
 
-    /**
-     */
     public function testSetInvalidAudioCodec()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
@@ -59,16 +57,12 @@ abstract class AudioTestCase extends TestCase
         $this->assertEquals(256, $format->getAudioKiloBitrate());
     }
 
-    /**
-     */
     public function testSetInvalidKiloBitrate()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setAudioKiloBitrate(0);
     }
 
-    /**
-     */
     public function testSetNegativeKiloBitrate()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
@@ -87,16 +81,12 @@ abstract class AudioTestCase extends TestCase
         $this->assertEquals(2, $format->getAudioChannels());
     }
 
-    /**
-     */
     public function testSetInvalidChannels()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setAudioChannels(0);
     }
 
-    /**
-     */
     public function testSetNegativeChannels()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');

--- a/tests/Unit/Format/Audio/AudioTestCase.php
+++ b/tests/Unit/Format/Audio/AudioTestCase.php
@@ -9,7 +9,11 @@ abstract class AudioTestCase extends TestCase
 {
     public function testExtraParams()
     {
-        foreach ($this->getFormat()->getExtraParams() as $param) {
+        $extraParams = $this->getFormat()->getExtraParams();
+
+        $this->assertIsArray($extraParams);
+
+        foreach ($extraParams as $param) {
             $this->assertScalar($param);
         }
     }
@@ -31,10 +35,10 @@ abstract class AudioTestCase extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testSetInvalidAudioCodec()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setAudioCodec('invalid-random-audio-codec');
     }
 
@@ -45,7 +49,7 @@ abstract class AudioTestCase extends TestCase
 
     public function testGetAudioKiloBitrate()
     {
-        $this->assertInternalType('integer', $this->getFormat()->getAudioKiloBitrate());
+        $this->assertIsInt($this->getFormat()->getAudioKiloBitrate());
     }
 
     public function testSetAudioKiloBitrate()
@@ -56,24 +60,24 @@ abstract class AudioTestCase extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testSetInvalidKiloBitrate()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setAudioKiloBitrate(0);
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testSetNegativeKiloBitrate()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setAudioKiloBitrate(-10);
     }
 
     public function testGetAudioChannels()
     {
-        $this->assertInternalType('null', $this->getFormat()->getAudioChannels());
+        $this->assertNull($this->getFormat()->getAudioChannels());
     }
 
     public function testSetAudioChannels()
@@ -84,18 +88,18 @@ abstract class AudioTestCase extends TestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testSetInvalidChannels()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setAudioChannels(0);
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testSetNegativeChannels()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setAudioChannels(-10);
     }
 

--- a/tests/Unit/Format/Video/VideoTestCase.php
+++ b/tests/Unit/Format/Video/VideoTestCase.php
@@ -14,7 +14,7 @@ abstract class VideoTestCase extends AudioTestCase
 
     public function testSupportBFrames()
     {
-        $this->assertInternalType('boolean', $this->getFormat()->supportBFrames());
+        $this->assertIsBool($this->getFormat()->supportBFrames());
     }
 
     public function testSetVideoCodec()
@@ -29,7 +29,7 @@ abstract class VideoTestCase extends AudioTestCase
 
     public function testGetKiloBitrate()
     {
-        $this->assertInternalType('integer', $this->getFormat()->getKiloBitrate());
+        $this->assertIsInt($this->getFormat()->getKiloBitrate());
     }
 
     public function testSetKiloBitrate()
@@ -40,10 +40,10 @@ abstract class VideoTestCase extends AudioTestCase
     }
 
     /**
-     * @expectedException FFMpeg\Exception\InvalidArgumentException
      */
     public function testSetInvalidVideoCodec()
     {
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setVideoCodec('invalid-random-video-codec');
     }
 
@@ -72,13 +72,13 @@ abstract class VideoTestCase extends AudioTestCase
 
     public function testGetPasses()
     {
-        $this->assertInternalType('integer', $this->getFormat()->getPasses());
+        $this->assertIsInt($this->getFormat()->getPasses());
         $this->assertGreaterThan(0, $this->getFormat()->getPasses());
     }
 
     public function testGetModulus()
     {
-        $this->assertInternalType('integer', $this->getFormat()->getModulus());
+        $this->assertIsInt($this->getFormat()->getModulus());
         $this->assertGreaterThan(0, $this->getFormat()->getModulus());
         $this->assertEquals(0, $this->getFormat()->getModulus() % 2);
     }

--- a/tests/Unit/Format/Video/VideoTestCase.php
+++ b/tests/Unit/Format/Video/VideoTestCase.php
@@ -54,7 +54,7 @@ abstract class VideoTestCase extends AudioTestCase
 
     public function testCreateProgressListener()
     {
-        $media = $this->getMock('FFMpeg\Media\MediaTypeInterface');
+        $media = $this->getMockBuilder('FFMpeg\Media\MediaTypeInterface')->getMock();
         $media->expects($this->any())
             ->method('getPathfile')
             ->will($this->returnValue(__FILE__));

--- a/tests/Unit/Format/Video/VideoTestCase.php
+++ b/tests/Unit/Format/Video/VideoTestCase.php
@@ -39,8 +39,6 @@ abstract class VideoTestCase extends AudioTestCase
         $this->assertEquals(2560, $format->getKiloBitrate());
     }
 
-    /**
-     */
     public function testSetInvalidVideoCodec()
     {
         $this->expectException('\FFMpeg\Exception\InvalidArgumentException');

--- a/tests/Unit/Media/AudioTest.php
+++ b/tests/Unit/Media/AudioTest.php
@@ -29,7 +29,7 @@ class AudioTest extends AbstractStreamableTestCase
         $audio = new Audio(__FILE__, $driver, $ffprobe);
         $audio->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Audio\AudioFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Audio\AudioFilterInterface')->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -50,7 +50,7 @@ class AudioTest extends AbstractStreamableTestCase
         $audio = new Audio(__FILE__, $driver, $ffprobe);
         $audio->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Video\VideoFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Video\VideoFilterInterface')->getMock();
 
         $filters->expects($this->never())
             ->method('add');
@@ -65,7 +65,7 @@ class AudioTest extends AbstractStreamableTestCase
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
 
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -91,12 +91,12 @@ class AudioTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -104,7 +104,7 @@ class AudioTest extends AbstractStreamableTestCase
 
         $audio = new Audio(__FILE__, $driver, $ffprobe);
 
-        $filter = $this->getMock('FFMpeg\Filters\Audio\AudioFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Audio\AudioFilterInterface')->getMock();
         $filter->expects($this->once())
             ->method('apply')
             ->with($audio, $format)
@@ -138,7 +138,7 @@ class AudioTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -180,7 +180,7 @@ class AudioTest extends AbstractStreamableTestCase
 
     public function provideSaveData()
     {
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -191,7 +191,7 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getAudioChannels')
             ->will($this->returnValue(5));
 
-        $audioFormat = $this->getMock('FFMpeg\Format\AudioInterface');
+        $audioFormat = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
         $audioFormat->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -205,7 +205,7 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getAudioCodec')
             ->will($this->returnValue('patati-patata-audio'));
 
-        $formatExtra = $this->getMock('FFMpeg\Format\AudioInterface');
+        $formatExtra = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
         $formatExtra->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('extra', 'param')));
@@ -216,7 +216,7 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getAudioChannels')
             ->will($this->returnValue(5));
 
-        $listeners = array($this->getMock('Alchemy\BinaryDriver\Listeners\ListenerInterface'));
+        $listeners = array($this->getMockBuilder('Alchemy\BinaryDriver\Listeners\ListenerInterface')->getMock());
 
         $progressableFormat = $this->getMockBuilder('Tests\FFMpeg\Unit\Media\AudioProg')
             ->disableOriginalConstructor()->getMock();
@@ -290,7 +290,7 @@ class AudioTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -317,7 +317,7 @@ class AudioTest extends AbstractStreamableTestCase
 
         $outputPathfile = '/target/file';
 
-        $format = $this->getMock('FFMpeg\Format\AudioInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('param')));

--- a/tests/Unit/Media/AudioTest.php
+++ b/tests/Unit/Media/AudioTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\FFMpeg\Unit\Media;
 
+use FFMpeg\Exception\RuntimeException;
 use FFMpeg\Media\Audio;
 use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
 use FFMpeg\Format\AudioInterface;
@@ -55,7 +56,7 @@ class AudioTest extends AbstractStreamableTestCase
         $filters->expects($this->never())
             ->method('add');
 
-        $this->setExpectedException('FFMpeg\Exception\InvalidArgumentException');
+        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
         $audio->addFilter($filter);
     }
 
@@ -70,19 +71,19 @@ class AudioTest extends AbstractStreamableTestCase
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
             ->will($this->returnValue($configuration));
 
-        $failure = new ExecutionFailureException('failed to encode');
+        $failure = new RuntimeException('failed to encode');
         $driver->expects($this->once())
             ->method('command')
             ->will($this->throwException($failure));
 
         $audio = new Audio(__FILE__, $driver, $ffprobe);
-        $this->setExpectedException('FFMpeg\Exception\RuntimeException');
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $audio->save($format, $outputPathfile);
     }
 

--- a/tests/Unit/Media/ClipTest.php
+++ b/tests/Unit/Media/ClipTest.php
@@ -35,7 +35,7 @@ class ClipTest extends AbstractMediaTestCase
 
         $outputPathfile = '/target/file';
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('getPasses')
             ->will($this->returnValue(1));

--- a/tests/Unit/Media/ConcatTest.php
+++ b/tests/Unit/Media/ConcatTest.php
@@ -34,7 +34,7 @@ class ConcatTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Concat\ConcatFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Concat\ConcatFilterInterface')->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -115,7 +115,7 @@ class ConcatTest extends AbstractMediaTestCase
 
         array_push($commands, $pathfile);
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -136,9 +136,9 @@ class ConcatTest extends AbstractMediaTestCase
                 array(
                     '-i', __FILE__,
                     '-i', 'concat-2.mp4',
-                    '-filter_complex', 
+                    '-filter_complex',
                     '[0:v:0] [0:a:0] [1:v:0] [1:a:0] concat=n=2:v=1:a=1 [v] [a]',
-                    '-map', '[v]', 
+                    '-map', '[v]',
                     '-map', '[a]'
                 ),
             ),

--- a/tests/Unit/Media/FrameTest.php
+++ b/tests/Unit/Media/FrameTest.php
@@ -36,7 +36,7 @@ class FrameTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Frame\FrameFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Frame\FrameFilterInterface')->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -78,7 +78,7 @@ class FrameTest extends AbstractMediaTestCase
             $frame->save($pathfile, $accurate, $base64);
         }
     }
-    
+
     public function provideSaveOptions()
     {
         return array(

--- a/tests/Unit/Media/GifTest.php
+++ b/tests/Unit/Media/GifTest.php
@@ -51,7 +51,7 @@ class GifTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Gif\GifFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Gif\GifFilterInterface')->getMock();
 
         $filters->expects($this->once())
             ->method('add')

--- a/tests/Unit/Media/VideoTest.php
+++ b/tests/Unit/Media/VideoTest.php
@@ -29,7 +29,7 @@ class VideoTest extends AbstractStreamableTestCase
         $video = new Video(__FILE__, $driver, $ffprobe);
         $video->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Video\VideoFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Video\VideoFilterInterface')->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -50,7 +50,7 @@ class VideoTest extends AbstractStreamableTestCase
         $video = new Video(__FILE__, $driver, $ffprobe);
         $video->setFiltersCollection($filters);
 
-        $filter = $this->getMock('FFMpeg\Filters\Audio\AudioFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Audio\AudioFilterInterface')->getMock();
 
         $filters->expects($this->once())
             ->method('add')
@@ -79,7 +79,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('getPasses')
             ->will($this->returnValue(1));
@@ -87,7 +87,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -108,7 +108,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
         $outputPathfile = '/target/file';
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -116,7 +116,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getPasses')
             ->will($this->returnValue(2));
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -124,7 +124,7 @@ class VideoTest extends AbstractStreamableTestCase
 
         $video = new Video(__FILE__, $driver, $ffprobe);
 
-        $filter = $this->getMock('FFMpeg\Filters\Video\VideoFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Video\VideoFilterInterface')->getMock();
         $filter->expects($this->once())
             ->method('apply')
             ->with($video, $format)
@@ -158,7 +158,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -233,7 +233,7 @@ class VideoTest extends AbstractStreamableTestCase
 
     public function provideSaveData()
     {
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -253,7 +253,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array('foo', 'bar')));
 
-        $format2 = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format2 = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format2->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -273,7 +273,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array('foo', 'bar')));
 
-        $audioFormat = $this->getMock('FFMpeg\Format\AudioInterface');
+        $audioFormat = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
         $audioFormat->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -290,7 +290,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getPasses')
             ->will($this->returnValue(1));
 
-        $audioVideoFormat = $this->getMock('FFMpeg\Format\VideoInterface');
+        $audioVideoFormat = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $audioVideoFormat->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -316,7 +316,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $audioVideoFormatSinglePass = $this->getMock('FFMpeg\Format\VideoInterface');
+        $audioVideoFormatSinglePass = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $audioVideoFormatSinglePass->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array()));
@@ -342,7 +342,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $formatExtra = $this->getMock('FFMpeg\Format\VideoInterface');
+        $formatExtra = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $formatExtra->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('extra', 'param')));
@@ -362,7 +362,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $formatExtra2 = $this->getMock('FFMpeg\Format\VideoInterface');
+        $formatExtra2 = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $formatExtra2->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('extra', 'param')));
@@ -382,7 +382,7 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getAdditionalParameters')
             ->will($this->returnValue(array()));
 
-        $listeners = array($this->getMock('Alchemy\BinaryDriver\Listeners\ListenerInterface'));
+        $listeners = array($this->getMockBuilder('Alchemy\BinaryDriver\Listeners\ListenerInterface')->getMock());
 
         $progressableFormat = $this->getMockBuilder('Tests\FFMpeg\Unit\Media\Prog')
             ->disableOriginalConstructor()->getMock();
@@ -585,7 +585,7 @@ class VideoTest extends AbstractStreamableTestCase
         $driver = $this->getFFMpegDriverMock();
         $ffprobe = $this->getFFProbeMock();
 
-        $configuration = $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getConfiguration')
@@ -612,7 +612,7 @@ class VideoTest extends AbstractStreamableTestCase
 
         $outputPathfile = '/target/file';
 
-        $format = $this->getMock('FFMpeg\Format\VideoInterface');
+        $format = $this->getMockBuilder('FFMpeg\Format\VideoInterface')->getMock();
         $format->expects($this->any())
             ->method('getExtraParams')
             ->will($this->returnValue(array('param')));

--- a/tests/Unit/Media/VideoTest.php
+++ b/tests/Unit/Media/VideoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\FFMpeg\Unit\Media;
 
+use FFMpeg\Exception\RuntimeException;
 use FFMpeg\Media\Video;
 use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
 use FFMpeg\Format\VideoInterface;
@@ -93,13 +94,13 @@ class VideoTest extends AbstractStreamableTestCase
             ->method('getConfiguration')
             ->will($this->returnValue($configuration));
 
-        $failure = new ExecutionFailureException('failed to encode');
+        $failure = new RuntimeException('failed to encode');
         $driver->expects($this->once())
             ->method('command')
             ->will($this->throwException($failure));
 
         $video = new Video(__FILE__, $driver, $ffprobe);
-        $this->setExpectedException('FFMpeg\Exception\RuntimeException');
+        $this->expectException('\FFMpeg\Exception\RuntimeException');
         $video->save($format, $outputPathfile);
     }
 

--- a/tests/Unit/Media/WaveformTest.php
+++ b/tests/Unit/Media/WaveformTest.php
@@ -25,7 +25,7 @@ class WaveformTest extends AbstractMediaTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filter = $this->getMock('FFMpeg\Filters\Waveform\WaveformFilterInterface');
+        $filter = $this->getMockBuilder('FFMpeg\Filters\Waveform\WaveformFilterInterface')->getMock();
 
         $filters->expects($this->once())
             ->method('add')

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -13,12 +13,12 @@ class TestCase extends BaseTestCase
 
     public function getLoggerMock()
     {
-        return $this->getMock('Psr\Log\LoggerInterface');
+        return $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
     }
 
     public function getCacheMock()
     {
-        return $this->getMock('Doctrine\Common\Cache\Cache');
+        return $this->getMockBuilder('Doctrine\Common\Cache\Cache')->getMock();
     }
 
     public function getTimeCodeMock()
@@ -86,17 +86,17 @@ class TestCase extends BaseTestCase
 
     public function getFFProbeParserMock()
     {
-        return $this->getMock('FFMpeg\FFProbe\OutputParserInterface');
+        return $this->getMockBuilder('FFMpeg\FFProbe\OutputParserInterface')->getMock();
     }
 
     public function getFFProbeOptionsTesterMock()
     {
-        return $this->getMock('FFMpeg\FFProbe\OptionsTesterInterface');
+        return $this->getMockBuilder('FFMpeg\FFProbe\OptionsTesterInterface')->getMock();
     }
 
     public function getFFProbeMapperMock()
     {
-        return $this->getMock('FFMpeg\FFProbe\MapperInterface');
+        return $this->getMockBuilder('FFMpeg\FFProbe\MapperInterface')->getMock();
     }
 
     public function getFFProbeOptionsTesterMockWithOptions(array $options)
@@ -114,7 +114,7 @@ class TestCase extends BaseTestCase
 
     public function getConfigurationMock()
     {
-        return $this->getMock('Alchemy\BinaryDriver\ConfigurationInterface');
+        return $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
     }
 
     public function getFormatMock()

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -2,15 +2,10 @@
 
 namespace Tests\FFMpeg\Unit;
 
-use PHPUnit\Framework\TestCase as BaseTestCase;
+use Tests\FFMpeg\BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    public function assertScalar($value)
-    {
-        $this->assertTrue(is_scalar($value));
-    }
-
     public function getLoggerMock()
     {
         return $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes -
| Related issues/PRs | -
| License            | MIT

#### What's in this PR?

Fixes tests on different php versions on travis. The ExecutionFailureException is used on same places falsely and can since change alchemy/binary-driver (https://github.com/alchemy-fr/BinaryDriver/pull/30/files) not longer used this way so I did go to the ffpeg runtimexception instead.

#### Why?

Tests should be run on all supported php versions

#### Example Usage

```bash
vendor/bin/simple-phpunit
```

#### To Do

- [x] Create tests
