### PR TITLE
Added support for adding -strict -2 for enabling aac on linux

### DIFF
--- a/src/FFMpeg/Media/AbstractVideo.php
+++ b/src/FFMpeg/Media/AbstractVideo.php
@@ -271,6 +271,11 @@ abstract class AbstractVideo extends Audio
                 $pass[] = '-passlogfile';
                 $pass[] = $passPrefix;
             }
+            
+            if($format->getAudioCodec() == 'aac'){
+                $pass[] = '-strict';
+                $pass[] = '-2';
+            }
 
             $pass[] = $outputPathfile;
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?
Enable -strict -2 for enabling aac in linux
