### PR TITLE
Added initial parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,18 @@ $format->setAdditionalParameters(array('foo', 'bar'));
 $video->save($format, 'video.avi');
 ```
 
+##### Add initial parameters
+
+You can also add initial parameters to your encoding requests based on your video format. This can be expecially handy in overriding a default input codec in FFMpeg.
+
+The argument of the setInitialParameters method is an array.
+
+```php
+$format = new FFMpeg\Format\Video\X264();
+$format->setInitialParameters(array('-acodec', 'libopus'));
+$video->save($format, 'video.avi');
+```
+
 ##### Create your own format
 
 The easiest way to create a format is to extend the abstract

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -35,6 +35,9 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     /** @var Array */
     protected $additionalParamaters;
 
+    /** @var Array */
+    protected $initialParamaters;
+
     /**
      * {@inheritdoc}
      */
@@ -118,6 +121,31 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
         }
 
         $this->additionalParamaters = $additionalParamaters;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInitialParameters()
+    {
+        return $this->initialParamaters;
+    }
+
+    /**
+     * Sets initial parameters.
+     *
+     * @param  array                    $initialParamaters
+     * @throws InvalidArgumentException
+     */
+    public function setInitialParameters($initialParamaters)
+    {
+        if (!is_array($initialParamaters)) {
+            throw new InvalidArgumentException('Wrong initialParamaters value');
+        }
+
+        $this->initialParamaters = $initialParamaters;
 
         return $this;
     }

--- a/src/FFMpeg/Format/VideoInterface.php
+++ b/src/FFMpeg/Format/VideoInterface.php
@@ -56,9 +56,16 @@ interface VideoInterface extends AudioInterface
     public function getAvailableVideoCodecs();
 
     /**
-     * Returns the list of available video codecs for this format.
+     * Returns the list of additional parameters for this format.
      *
      * @return array
      */
     public function getAdditionalParameters();
+
+    /**
+     * Returns the list of initial parameters for this format
+     *
+     * @return array
+     */
+    public function getInitialParameters();
 }

--- a/src/FFMpeg/Media/AbstractVideo.php
+++ b/src/FFMpeg/Media/AbstractVideo.php
@@ -134,7 +134,7 @@ abstract class AbstractVideo extends Audio
      */
     protected function buildCommand(FormatInterface $format, $outputPathfile)
     {
-        $commands = $this->basePartOfCommand();
+        $commands = $this->basePartOfCommand($format);
 
         $filters = clone $this->filters;
         $filters->add(new SimpleFilter($format->getExtraParams(), 10));
@@ -283,10 +283,25 @@ abstract class AbstractVideo extends Audio
     /**
      * Return base part of command.
      *
+     * @param FormatInterface $format
      * @return array
      */
-    protected function basePartOfCommand()
+    protected function basePartOfCommand(FormatInterface $format)
     {
-        return array('-y', '-i', $this->pathfile);
+        $commands = array('-y');
+
+        // If the user passed some initial parameters
+        if ($format instanceof VideoInterface) {
+            if (null !== $format->getInitialParameters()) {
+                foreach ($format->getInitialParameters() as $initialParameter) {
+                    $commands[] = $initialParameter;
+                }
+            }
+        }
+
+        $commands[] = '-i';
+        $commands[] = $this->pathfile;
+
+        return $commands;
     }
 }

--- a/src/FFMpeg/Media/Clip.php
+++ b/src/FFMpeg/Media/Clip.php
@@ -4,6 +4,7 @@ namespace FFMpeg\Media;
 use FFMpeg\Driver\FFMpegDriver;
 use FFMpeg\FFProbe;
 use FFMpeg\Coordinate\TimeCode;
+use FFMpeg\Format\FormatInterface;
 
 /**
  * Video clip.
@@ -34,6 +35,7 @@ class Clip extends Video
     /**
      * Returns the video related to the frame.
      *
+     * @param FormatInterface $format
      * @return Video
      */
     public function getVideo()
@@ -46,7 +48,7 @@ class Clip extends Video
      *
      * @return array
      */
-    protected function basePartOfCommand()
+    protected function basePartOfCommand(FormatInterface $format)
     {
         $arr = array('-y', '-ss', (string) $this->start, '-i', $this->pathfile);
 

--- a/tests/Unit/Format/Video/InitialParametersTest.php
+++ b/tests/Unit/Format/Video/InitialParametersTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Format\Video;
+
+use FFMpeg\Format\Video\X264;
+use Tests\FFMpeg\Unit\TestCase;
+
+class InitialParametersTest extends TestCase
+{
+    public function testApplyInitialParameters()
+    {
+        $format = new X264();
+        $format->setInitialParameters(array('-acodec', 'libopus'));
+        $this->assertEquals(array('-acodec', 'libopus'), $format->getInitialParameters());
+    }
+}


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #625, #675
| License            | MIT

#### What's in this PR?
This is a similar method to setAdditionalParamaters. It allows you to instead set an array of 'initial' parameters that are added before the input file. I needed this mainly because I'm recording realtime video in OPUS and transcoding the audio for playback to AAC. An ffmpeg build with libopus requires you to pass '-acodec libopus' otherwise it defaults to the default opus codec which doesn't work very well.

It's fairly common when using the newer proprietary codecs to require this ability.

#### Why?

This fixes not being able to pass initial parameters before the input file is added to the build command. #625, #675

#### Example Usage

```php
$format = new FFMpeg\Format\Video\X264();
$format->setInitialParameters(array('-acodec', 'libopus'));
$video->save($format, 'video.avi');
```
#### Attribution goes to @throttlehead, I've just added the unit test
