### PR TITLE
Fixed typo in the readme referring to FrameRate

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ $video->filters()->framerate($framerate, $gop);
 
 The framerate filter takes two parameters:
 
-- `$framerate`, an instance of `FFMpeg\Coordinate\Framerate`
+- `$framerate`, an instance of `FFMpeg\Coordinate\FrameRate`
 - `$gop`, a [GOP](https://wikipedia.org/wiki/Group_of_pictures) value (integer)
 
 ###### Synchronize


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | none
| Related issues/PRs | none
| License            | MIT

#### What's in this PR?

Simple typo fix, the readme is referring to the incorrectly cased version of the class.

#### Why?

Documentation

#### Example Usage

```php
use FFMpeg\Coordinate\FrameRate;
```

#### BC Breaks/Deprecations

None

#### To Do

None
