### PR TITLE
Add Support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: nightly
+      env:
+        - COMPOSER_DEV_STABILITY=true
 
 before_install:
   - sudo add-apt-repository ppa:mc3man/trusty-media -y
@@ -45,6 +48,10 @@ before_install:
   - |
     if [ "$COMPOSER_FLAGS" == "--prefer-lowest" ]; then
       composer require "roave/security-advisories" dev-master --no-update
+    fi;
+  - |
+    if [ "$COMPOSER_DEV_STABILITY" == "true" ]; then
+      composer config minimum-stability dev
     fi;
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.9 || ^7.0",
+        "php": ">=5.3.9",
         "alchemy/binary-driver": "^1.5 || ~2.0.0 || ^5.0",
         "doctrine/cache": "^1.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
@@ -58,7 +58,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.7-dev"
+            "dev-master": "0.x-dev"
         }
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes -
| Related issues/PRs | -
| License            | MIT

#### What's in this PR?

Update add tests again PHP 8.

#### Why?

That the package can be install for newer php versions.

#### Example Usage

Install PHP 8 / Nightly and use PHP.

#### To Do

- [ ] Needs https://github.com/romainneutron/Temporary-Filesystem/pull/16