### PR TITLE
Inputs parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-#/nbproject/
+/nbproject/
 /vendor/
 /docs/build
 composer.phar

--- a/README.md
+++ b/README.md
@@ -596,6 +596,25 @@ $advancedMedia
     ->setAdditionalParameters(array('the', 'params', 'that', 'will', 'be', 'added', 'at', 'the', 'end', 'of', 'the', 'command'));
 ```
 
+##### Add inputs parameters
+If you need you can add extra parameters for each input of the AdvancedMedia:
+
+```php
+$inputs = [
+    'color=c=black:s=640x480',
+    'video_2.mp4',
+    'video_3.mp4',
+];
+$extraInputsParams = [
+    0 => ['-f', 'lavfi', '-t', '10'],          // extra params for firts input 'color=c=black:s=640x480' (key 0 in $inputs array)
+    2 => ['some', 'other', 'extra', 'params'], // extra params for third input 'video_3.mp4' (key 2 in $inputs array)
+];
+$advancedMedia = $ffmpeg->openAdvanced($inputs);
+$advancedMedia->setInputsParameters($extraInputsParams);
+```
+Final command will be looks like:
+`-f lavfi -t 10 -i color=c=black:s=640x480 -i /path/to/video_2.mp4 some other extra params -i /path/to/video_3.mp4`
+
 #### Formats
 
 A format implements `FFMpeg\Format\FormatInterface`. To save to a video file,

--- a/src/FFMpeg/Media/AdvancedMedia.php
+++ b/src/FFMpeg/Media/AdvancedMedia.php
@@ -42,6 +42,12 @@ class AdvancedMedia extends AbstractMediaType
     private $additionalParameters;
 
     /**
+     *
+     * @var array[]
+     */
+    private $inputsParameters;
+    
+    /**
      * @var string[]
      */
     private $mapCommands;
@@ -74,6 +80,7 @@ class AdvancedMedia extends AbstractMediaType
         $this->inputs = $inputs;
         $this->initialParameters = array();
         $this->additionalParameters = array();
+        $this->inputsParameters = array();
         $this->mapCommands = array();
         $this->listeners = array();
     }
@@ -156,6 +163,24 @@ class AdvancedMedia extends AbstractMediaType
         return $this;
     }
 
+    /**
+     * @return array
+     */
+    public function getInputsParameters()
+    {
+        return $this->inputsParameters;
+    }
+
+    /**
+     * @param array $parameters
+     * @return AdvancedMedia
+     */
+    public function setInputsParameters(array $parameters)
+    {
+        $this->inputsParameters = $parameters;
+        return $this;
+    }
+    
     /**
      * @return string[]
      */
@@ -392,7 +417,8 @@ class AdvancedMedia extends AbstractMediaType
     private function buildInputsPart(array $inputs)
     {
         $commands = array();
-        foreach ($inputs as $input) {
+        foreach ($inputs as $key => $input) {
+            $commands = array_merge($commands, $this->mapInput($key));
             $commands[] = '-i';
             $commands[] = $input;
         }
@@ -400,6 +426,25 @@ class AdvancedMedia extends AbstractMediaType
         return $commands;
     }
 
+    /**
+     * Add parameters to inputs
+     * 
+     * @param int $inputKey
+     * @return type
+     */
+    private function mapInput(int $inputKey)
+    {
+        $commands = array();
+
+        if (isset($this->inputsParameters[$inputKey])) {
+            foreach ($this->inputsParameters[$inputKey] as $param) {
+                $commands[] = $param;
+            }
+        }
+
+        return $commands;
+    }
+    
     /**
      * Build "-filter_complex" part of the ffmpeg command.
      *


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| License            | MIT

#### What's in this PR?

Gives the opportunity to add parameters for each input for `AdvancedMedia`.

#### Example Usage

```php
$inputs = [
    'color=c=black:s=640x480',
    'video_2.mp4',
    'video_3.mp4',
];
$extraInputsParams = [
    0 => ['-f', 'lavfi', '-t', '10'],          // extra params for firts input 'color=c=black:s=640x480' (key 0 in $inputs array)
    2 => ['some', 'other', 'extra', 'params'], // extra params for third input 'video_3.mp4' (key 2 in $inputs array)
];
$advancedMedia = $ffmpeg->openAdvanced($inputs);
$advancedMedia->setInputsParameters($extraInputsParams);
```

#### To Do

- [ ] Create tests
