### PR TITLE
Allow newer version of temporary filesystem for php 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "alchemy/binary-driver": "^1.5 || ~2.0.0 || ^5.0",
         "doctrine/cache": "^1.0",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "neutron/temporary-filesystem": "^2.1.1"
+        "neutron/temporary-filesystem": "^2.1.1 || ^3.0"
     },
     "suggest": {
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | -
| Related issues/PRs | https://github.com/romainneutron/Temporary-Filesystem/pull/16, #747
| License            | MIT

#### What's in this PR?

Allow newer version of temporary filesystem.

#### Why?

Allow version which is compatible to php 8.


#### BC Breaks/Deprecations

No BC Break.

