### PR TITLE
additionalParameters capability in audio formats

### DIFF
--- a/src/FFMpeg/Format/Audio/DefaultAudio.php
+++ b/src/FFMpeg/Format/Audio/DefaultAudio.php
@@ -30,6 +30,9 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     /** @var integer */
     protected $audioChannels = null;
 
+    /** @var Array */
+    protected $additionalParamaters;
+    
     /**
      * {@inheritdoc}
      */
@@ -138,5 +141,30 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     public function getPasses()
     {
         return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdditionalParameters()
+    {
+        return $this->additionalParamaters;
+    }
+
+    /**
+     * Sets additional parameters.
+     *
+     * @param  array                    $additionalParamaters
+     * @throws InvalidArgumentException
+     */
+    public function setAdditionalParameters($additionalParamaters)
+    {
+        if (!is_array($additionalParamaters)) {
+            throw new InvalidArgumentException('Wrong additionalParamaters value. Must be an array.');
+        }
+
+        $this->additionalParamaters = $additionalParamaters;
+
+        return $this;
     }
 }

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -122,6 +122,14 @@ class Audio extends AbstractStreamableMedia
             $commands[] = '-ac';
             $commands[] = $format->getAudioChannels();
         }
+
+        // If the user passed some additional parameters
+        if (null !== $format->getAdditionalParameters()) {
+            foreach ($format->getAdditionalParameters() as $additionalParameter) {
+                $commands[] = $additionalParameter;
+            }
+        }
+
         $commands[] = $outputPathfile;
 
         return $commands;


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | maybe
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | none
| Related issues/PRs | none
| License            | MIT

Hi,

My first time creating a pull request on github so please go easy on me :-D Apologies for anything i might have not gotten right.

#### What's in this PR?

I have added get and set functions for additionalParameters in Format\Audio\DefaultAudio.php and included the new additionalParameters variable to be included in the build function in Media\Audio.php

#### Why?

Which problem does the PR fix?

I was trying to perform HLS encoding of an audio (mp3) file which requires me to set up some additional command line switches (additional parameters). I figured out I could set them in a video format (any formats inherited from the DefaultVideo) but not audio formats (any formats inherited from the DefaultAudio class)

#### To Do

- [ ] Create tests

Have not created any tests.
