### PR TITLE
Add ability to disable -b:v

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ video. Frames can be extracted.
 You can transcode videos using the `FFMpeg\Media\Video:save` method. You will
 pass a `FFMpeg\Format\FormatInterface` for that.
 
-Please note that audio and video bitrate are set on the format.
+Please note that audio and video bitrate are set on the format. You can disable the `-b:v` option by setting the kilo bitrate to 0.
 
 ```php
 $format = new FFMpeg\Format\Video\X264();

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -54,7 +54,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
      */
     public function setKiloBitrate($kiloBitrate)
     {
-        if ($kiloBitrate < 1) {
+        if ($kiloBitrate < 0) {
             throw new InvalidArgumentException('Wrong kiloBitrate value');
         }
 

--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -81,7 +81,7 @@ class X264 extends DefaultVideo
      */
     public function getPasses()
     {
-        return $this->passes;
+        return $this->getKiloBitrate() === 0 ? 1 : $this->passes;
     }
 
     /**

--- a/src/FFMpeg/Media/AbstractVideo.php
+++ b/src/FFMpeg/Media/AbstractVideo.php
@@ -158,8 +158,11 @@ abstract class AbstractVideo extends Audio
         }
 
         if ($format instanceof VideoInterface) {
-            $commands[] = '-b:v';
-            $commands[] = $format->getKiloBitrate() . 'k';
+            if ($format->getKiloBitrate() !== 0) {
+                $commands[] = '-b:v';
+                $commands[] = $format->getKiloBitrate() . 'k';
+            }
+
             $commands[] = '-refs';
             $commands[] = '6';
             $commands[] = '-coder';

--- a/tests/Functional/AudioConcatenationTest.php
+++ b/tests/Functional/AudioConcatenationTest.php
@@ -10,21 +10,21 @@ class AudioConcatenationTest extends FunctionalTestCase
     public function testSimpleAudioFileConcatTest()
     {
         $ffmpeg = $this->getFFMpeg();
-        
+
         $files = [
-            __DIR__ . '/../files/Jahzzar_-_05_-_Siesta.mp3',
-            __DIR__ . '/../files/02_-_Favorite_Secrets.mp3',
+            realpath(__DIR__ . '/../files/Jahzzar_-_05_-_Siesta.mp3'),
+            realpath(__DIR__ . '/../files/02_-_Favorite_Secrets.mp3'),
         ];
 
         $audio = $ffmpeg->open(reset($files));
 
         $this->assertInstanceOf('FFMpeg\Media\Audio', $audio);
-        
+
         clearstatcache();
         $filename = __DIR__ . '/output/concat-output.mp3';
 
         $audio->concat($files)->saveFromSameCodecs($filename, TRUE);
-        
+
         $this->assertFileExists($filename);
         unlink($filename);
     }

--- a/tests/Unit/Format/Video/VideoTestCase.php
+++ b/tests/Unit/Format/Video/VideoTestCase.php
@@ -42,14 +42,14 @@ abstract class VideoTestCase extends AudioTestCase
 
     public function testSetKiloBitrateBelowZero()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException('FFMpeg\Exception\InvalidArgumentException');
         $format = $this->getFormat();
         $format->setKiloBitrate(-1);
     }
 
     public function testSetInvalidVideoCodec()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException('FFMpeg\Exception\InvalidArgumentException');
         $this->getFormat()->setVideoCodec('invalid-random-video-codec');
     }
 

--- a/tests/Unit/Format/Video/VideoTestCase.php
+++ b/tests/Unit/Format/Video/VideoTestCase.php
@@ -3,6 +3,7 @@
 namespace Tests\FFMpeg\Unit\Format\Video;
 
 use Tests\FFMpeg\Unit\Format\Audio\AudioTestCase;
+use FFMpeg\Exception\InvalidArgumentException;
 
 abstract class VideoTestCase extends AudioTestCase
 {
@@ -39,9 +40,16 @@ abstract class VideoTestCase extends AudioTestCase
         $this->assertEquals(2560, $format->getKiloBitrate());
     }
 
+    public function testSetKiloBitrateBelowZero()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $format = $this->getFormat();
+        $format->setKiloBitrate(-1);
+    }
+
     public function testSetInvalidVideoCodec()
     {
-        $this->expectException('\FFMpeg\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->getFormat()->setVideoCodec('invalid-random-video-codec');
     }
 

--- a/tests/Unit/Format/Video/VideoTestCase.php
+++ b/tests/Unit/Format/Video/VideoTestCase.php
@@ -3,7 +3,6 @@
 namespace Tests\FFMpeg\Unit\Format\Video;
 
 use Tests\FFMpeg\Unit\Format\Audio\AudioTestCase;
-use FFMpeg\Exception\InvalidArgumentException;
 
 abstract class VideoTestCase extends AudioTestCase
 {

--- a/tests/Unit/Media/VideoTest.php
+++ b/tests/Unit/Media/VideoTest.php
@@ -4,6 +4,7 @@ namespace Tests\FFMpeg\Unit\Media;
 
 use FFMpeg\Exception\RuntimeException;
 use FFMpeg\Media\Video;
+use FFMpeg\Format\Video\X264;
 use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
 use FFMpeg\Format\VideoInterface;
 
@@ -675,6 +676,35 @@ class VideoTest extends AbstractStreamableTestCase
             }
             $n++;
         }
+    }
+
+    public function testCaseWhereKiloBitRateIsEqualToZero()
+    {
+        $driver = $this->getFFMpegDriverMock();
+        $ffprobe = $this->getFFProbeMock();
+
+        $pathfile = '/target/destination';
+        $outputPathfile = '/target/file';
+
+        $format = new X264();
+        $format->setKiloBitrate(0);
+
+        $configuration = $this->getMockBuilder('Alchemy\BinaryDriver\ConfigurationInterface')->getMock();
+
+        $driver->expects($this->any())
+            ->method('getConfiguration')
+            ->will($this->returnValue($configuration));
+
+        $driver->expects($this->exactly(1))
+            ->method('command')
+            ->with($this->isType('array'), false, $this->anything())
+            ->will($this->returnCallback(function ($commands, $errors, $listeners) {
+                var_dump($commands);
+                $this->assertTrue(!in_array('-b:v', $commands));
+            }));
+
+        $video = new Video(__FILE__, $driver, $ffprobe);
+        $video->save($format, $outputPathfile);
     }
 
     public function getClassName()


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #418 
| Related issues/PRs | #418
| License            | MIT

#### What's in this PR?

By passing `0` to `setKiloBitrate()` we can bypass setting `-b:v` setting.

#### Why?

Sometimes we may prefer not to use `-b:v` in favor to `crf`.

#### BC Breaks/Deprecations

No BC breaks.

#### To Do

- [x] Create tests
