### PR TITLE
Add spectrum audio filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,14 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
+      dist: bionic
     - php: nightly
       env:
         - COMPOSER_DEV_STABILITY=true
 
 before_install:
-  - sudo add-apt-repository ppa:mc3man/trusty-media -y
+  - sudo add-apt-repository ppa:mc3man/${TRAVIS_DIST}-media -y
   - sudo apt-get update -q
   - composer self-update
   - echo "$PHPUNIT_VERSION"

--- a/src/FFMpeg/Coordinate/AspectRatio.php
+++ b/src/FFMpeg/Coordinate/AspectRatio.php
@@ -142,7 +142,7 @@ class AspectRatio
      * custom ratio need to be used, disable it.
      *
      * @param Dimension $dimension
-     * @param Boolean   $forceStandards Whether to force or not standard ratios
+     * @param bool   $forceStandards Whether to force or not standard ratios
      *
      * @return AspectRatio
      *

--- a/src/FFMpeg/FFProbe/DataMapping/AbstractData.php
+++ b/src/FFMpeg/FFProbe/DataMapping/AbstractData.php
@@ -24,7 +24,7 @@ abstract class AbstractData implements \Countable
      * Returns true if data has property.
      *
      * @param  string  $property
-     * @return Boolean
+     * @return bool
      */
     public function has($property)
     {

--- a/src/FFMpeg/FFProbe/DataMapping/Stream.php
+++ b/src/FFMpeg/FFProbe/DataMapping/Stream.php
@@ -20,7 +20,7 @@ class Stream extends AbstractData
     /**
      * Returns true if the stream is an audio stream.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isAudio()
     {
@@ -30,7 +30,7 @@ class Stream extends AbstractData
     /**
      * Returns true if the stream is a video stream.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isVideo()
     {

--- a/src/FFMpeg/FFProbe/OptionsTester.php
+++ b/src/FFMpeg/FFProbe/OptionsTester.php
@@ -42,7 +42,7 @@ class OptionsTester implements OptionsTesterInterface
 
         $output = $this->retrieveHelpOutput();
 
-        $ret = (Boolean) preg_match('/^'.$name.'/m', $output);
+        $ret = (bool) preg_match('/^'.$name.'/m', $output);
 
         $this->cache->save($id, $ret);
 

--- a/src/FFMpeg/FFProbe/OptionsTesterInterface.php
+++ b/src/FFMpeg/FFProbe/OptionsTesterInterface.php
@@ -18,7 +18,7 @@ interface OptionsTesterInterface
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return bool
      */
     public function has($name);
 }

--- a/src/FFMpeg/Filters/FiltersCollection.php
+++ b/src/FFMpeg/Filters/FiltersCollection.php
@@ -38,7 +38,7 @@ class FiltersCollection implements \Countable, \IteratorAggregate
             return 0;
         }
 
-        return count(call_user_func_array('array_merge', $this->filters));
+        return count(call_user_func_array('array_merge', array_values($this->filters)));
     }
 
     /**
@@ -51,7 +51,7 @@ class FiltersCollection implements \Countable, \IteratorAggregate
                 $this->sorted = $this->filters;
             } else {
                 krsort($this->filters);
-                $this->sorted = call_user_func_array('array_merge', $this->filters);
+                $this->sorted = call_user_func_array('array_merge', array_values($this->filters));
             }
         }
 

--- a/src/FFMpeg/Filters/Video/ResizeFilter.php
+++ b/src/FFMpeg/Filters/Video/ResizeFilter.php
@@ -31,7 +31,7 @@ class ResizeFilter implements VideoFilterInterface
     private $dimension;
     /** @var string */
     private $mode;
-    /** @var Boolean */
+    /** @var bool */
     private $forceStandards;
     /** @var integer */
     private $priority;
@@ -69,7 +69,7 @@ class ResizeFilter implements VideoFilterInterface
     }
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function areStandardsForced()
     {

--- a/src/FFMpeg/Filters/Video/VideoFilters.php
+++ b/src/FFMpeg/Filters/Video/VideoFilters.php
@@ -31,7 +31,7 @@ class VideoFilters extends AudioFilters
      *
      * @param Dimension $dimension
      * @param string    $mode
-     * @param Boolean   $forceStandards
+     * @param bool   $forceStandards
      *
      * @return VideoFilters
      */

--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -42,7 +42,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
     /** @var string */
     private $pathfile;
 
-    /** @var Boolean */
+    /** @var bool */
     private $initialized = false;
 
     /** @var integer */

--- a/src/FFMpeg/Format/VideoInterface.php
+++ b/src/FFMpeg/Format/VideoInterface.php
@@ -44,7 +44,7 @@ interface VideoInterface extends AudioInterface
      *
      * @see https://wikipedia.org/wiki/Video_compression_picture_types
      *
-     * @return Boolean
+     * @return bool
      */
     public function supportBFrames();
 

--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -79,7 +79,7 @@ class Frame extends AbstractMediaType
      * Uses the `unaccurate method by default.`
      *
      * @param string  $pathfile
-     * @param Boolean $accurate
+     * @param bool $accurate
      *
      * @return Frame
      *

--- a/src/FFMpeg/Media/Spectrum.php
+++ b/src/FFMpeg/Media/Spectrum.php
@@ -1,0 +1,601 @@
+<?php
+
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FFMpeg\Media;
+
+use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use FFMpeg\Driver\FFMpegDriver;
+use FFMpeg\Exception\InvalidArgumentException;
+use FFMpeg\Exception\RuntimeException;
+use FFMpeg\FFProbe;
+use FFMpeg\Filters\Waveform\WaveformFilterInterface;
+use FFMpeg\Filters\Waveform\WaveformFilters;
+
+/**
+ * Class Spectrum
+ * Generates an audio spectrum image using FFMPeg's `showspectrumpic` command
+ * @see https://ffmpeg.org/ffmpeg-filters.html#showspectrumpic
+ * @author Marcus Bointon <marcus@synchromedia.co.uk>
+ * @package FFMpeg\Media
+ */
+class Spectrum extends Waveform
+{
+    const DEFAULT_MODE = 'combined';
+    const DEFAULT_COLOR = 'intensity';
+    const DEFAULT_SCALE = 'log';
+    const DEFAULT_FSCALE = 'lin';
+    const DEFAULT_SATURATION = 1.0;
+    const DEFAULT_WIN_FUNC = 'hann';
+    const DEFAULT_ORIENTATION = 'vertical';
+    const DEFAULT_GAIN = 1.0;
+    const DEFAULT_LEGEND = true;
+    const DEFAULT_ROTATION = 0.0;
+    const DEFAULT_START = 0;
+    const DEFAULT_STOP = 0;
+
+    /**
+     * Whether to generate a `combined` spectrogram for all channels, or a `separate` one for each
+     * @var string
+     */
+    protected $mode = self::DEFAULT_MODE;
+    /**
+     * The color palette to use, see setColor() for options
+     * @var string
+     */
+    protected $color = self::DEFAULT_COLOR;
+    /**
+     * The scale to use for color intensity
+     * @var string
+     */
+    protected $scale = self::DEFAULT_SCALE;
+    /**
+     * The scale to use for the frequency axis
+     * @var string
+     */
+    protected $fscale = self::DEFAULT_FSCALE;
+    /**
+     * A saturation scaling factor, between -10.0 and 10.0. Negative values invert the color palette
+     * @var float
+     */
+    protected $saturation = self::DEFAULT_SATURATION;
+    /**
+     * The windowing function to use when calculating the spectrum. See setWinFunc() for options
+     * @var string
+     */
+    protected $win_func = self::DEFAULT_WIN_FUNC;
+    /**
+     * Frequency axis orientation, `horizontal` or `vertical`
+     * @var string
+     */
+    protected $orientation = self::DEFAULT_ORIENTATION;
+    /**
+     * Gain for calculating color values
+     * @var float
+     */
+    protected $gain = self::DEFAULT_GAIN;
+    /**
+     * Whether to display axes and labels
+     * @var bool
+     */
+    protected $legend = self::DEFAULT_LEGEND;
+    /**
+     * Rotation of colors within the palette, between -1.0 and 1.0
+     * @var float
+     */
+    protected $rotation = self::DEFAULT_ROTATION;
+    /**
+     * Starting frequency for the spectrum in Hz. Must be positive and not greater than stop frequency
+     * @var int
+     */
+    protected $start = self::DEFAULT_START;
+    /**
+     * Ending frequency for the spectrum in Hz. Must be positive and not less than start frequency
+     * @var int
+     */
+    protected $stop = self::DEFAULT_STOP;
+
+    /**
+     * Spectrum constructor.
+     *
+     * @param Audio $audio
+     * @param FFMpegDriver $driver
+     * @param FFProbe $ffprobe
+     * @param int $width
+     * @param int $height
+     * @param array $colors Note that this is not used, just here for compatibility with the Waveform parent
+     */
+    public function __construct(
+        Audio $audio,
+        FFMpegDriver $driver,
+        FFProbe $ffprobe,
+        $width,
+        $height,
+        $colors = array(self::DEFAULT_COLOR)
+    ) {
+        parent::__construct($audio, $driver, $ffprobe, $width, $height);
+        $this->audio = $audio;
+    }
+
+    /**
+     * Set the rendering mode.
+     *
+     * @param string $mode `combined` to create a single spectrogram for all channels, or `separate` for each channel separately, all within the same image
+     *
+     * @return $this
+     */
+    public function setMode($mode = 'combined')
+    {
+        static $modes = array(
+            'combined',
+            'separate',
+        );
+        if (! in_array($mode, $modes, true)) {
+            throw new InvalidArgumentException('Unknown mode. Valid values are: ' . implode(', ', $modes));
+        }
+        $this->mode = $mode;
+
+        return $this;
+    }
+
+    /**
+     * Get the current rendering mode.
+     * @return string
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    /**
+     * Set the color palette to use.
+     *
+     * @param string $color One of the available preset palette names: `channel`, `intensity`, `moreland`, `nebulae`, `fire`, `fiery`, `fruit`, `cool`, `magma`, `green`, `viridis`, `plasma`, `cividis`, `terrain`, or `random` to have it pick a random one
+     *
+     * @return $this
+     */
+    public function setColor($color = 'intensity')
+    {
+        static $modes = array(
+            'channel',
+            'intensity',
+            'moreland',
+            'nebulae',
+            'fire',
+            'fiery',
+            'fruit',
+            'cool',
+            'magma',
+            'green',
+            'viridis',
+            'plasma',
+            'cividis',
+            'terrain',
+        );
+        if ($color === 'random') {
+            $this->color = array_rand($modes);
+
+            return $this;
+        }
+        if (!in_array($color, $modes, true)) {
+            throw new InvalidArgumentException('Unknown color mode. Valid values are: ' . implode(', ', $modes));
+        }
+        $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * Get the current color palette.
+     *
+     * @return string
+     */
+    public function getColor()
+    {
+        return $this->color;
+    }
+
+    /**
+     * Set the scale to use for color intensity
+     *
+     * @param string $scale One of `lin`, `sqrt`, `log`, `4thrt`, or `5thrt`.
+     *
+     * @return $this
+     */
+    public function setScale($scale = 'log')
+    {
+        static $scales = array(
+            'lin',
+            'sqrt',
+            'log',
+            '4thrt',
+            '5thrt',
+        );
+        if (! in_array($scale, $scales, true)) {
+            throw new InvalidArgumentException('Unknown scale. Valid values are: ' . implode(', ', $scales));
+        }
+        $this->scale = $scale;
+
+        return $this;
+    }
+
+    /**
+     * Get the current color intensity scale.
+     *
+     * @return string
+     */
+    public function getScale()
+    {
+        return $this->scale;
+    }
+
+    /**
+     * Set the frequency axis scale.
+     *
+     * @param string $fscale One of `lin` or `log`.
+     *
+     * @return $this
+     */
+    public function setFscale($fscale = 'lin')
+    {
+        static $fscales = array(
+            'lin',
+            'log',
+        );
+        if (! in_array($fscale, $fscales, true)) {
+            throw new InvalidArgumentException('Unknown fscale. Valid values are: ' . implode(', ', $fscales));
+        }
+        $this->fscale = $fscale;
+
+        return $this;
+    }
+
+    /**
+     * Get the current frequency axis scale.
+     *
+     * @return string
+     */
+    public function getFscale()
+    {
+        return $this->fscale;
+    }
+
+    /**
+     * Set the color saturation scaling factor.
+     *
+     * @param float $saturation A value between -10.0 and 10.0 to multiply saturation values by. Negative values invert the saturation.
+     *
+     * @return $this
+     */
+    public function setSaturation($saturation = 1.0)
+    {
+        $saturation = (float)$saturation;
+        if ($saturation < -10.0 || $saturation > 10.0) {
+            throw new InvalidArgumentException('Saturation must be between -10.0 and 10.0.');
+        }
+        $this->saturation = $saturation;
+
+        return $this;
+    }
+
+    /**
+     * Get the current saturation scaling value.
+     *
+     * @return float
+     */
+    public function getSaturation()
+    {
+        return $this->saturation;
+    }
+
+    /**
+     * Set the windowing function to use when calculating the spectrum.
+     *
+     * @param string $win_func One of `rect`, `bartlett`, `hann`, `hanning`, `hamming`, `blackman`, `welch`, `flattop`, `bharris`, `bnuttall`, `bhann`, `sine`, `nuttall`, `lanczos`, `gauss`, `tukey`, `dolph`, `cauchy`, `parzen`, `poisson`, or `bohman`.
+ *
+     * @return $this
+     */
+    public function setWinFunc($win_func = 'hann')
+    {
+        static $win_funcs = array(
+            'rect',
+            'bartlett',
+            'hann',
+            'hanning',
+            'hamming',
+            'blackman',
+            'welch',
+            'flattop',
+            'bharris',
+            'bnuttall',
+            'bhann',
+            'sine',
+            'nuttall',
+            'lanczos',
+            'gauss',
+            'tukey',
+            'dolph',
+            'cauchy',
+            'parzen',
+            'poisson',
+            'bohman',
+        );
+        if (! in_array($win_func, $win_funcs, true)) {
+            throw new InvalidArgumentException('Unknown win_func. Valid values are: ' . implode(', ', $win_funcs));
+        }
+        $this->win_func = $win_func;
+
+        return $this;
+    }
+
+    /**
+     * Get the current windowing function.
+     *
+     * @return string
+     */
+    public function getWinFunc()
+    {
+        return $this->win_func;
+    }
+
+    /**
+     * Set the orientation of the generated spectrum.
+     *
+     * @param string $orientation `vertical` or `horizontal`
+     *
+     * @return $this
+     */
+    public function setOrientation($orientation = 'vertical')
+    {
+        static $orientations = array(
+            'vertical',
+            'horizontal',
+        );
+        if (! in_array($orientation, $orientations, true)) {
+            throw new InvalidArgumentException(
+                'Unknown orientation. Valid values are: ' . implode(', ', $orientations)
+            );
+        }
+        $this->orientation = $orientation;
+
+        return $this;
+    }
+
+    /**
+     * Get the current orientation.
+     *
+     * @return string
+     */
+    public function getOrientation()
+    {
+        return $this->orientation;
+    }
+
+    /**
+     * Set the gain used for calculating colour values.
+     *
+     * @param float $gain A multiplying factor: Use larger values for files with quieter audio.
+     *
+     * @return $this
+     */
+    public function setGain($gain = 1.0)
+    {
+        $this->gain = (float)$gain;
+
+        return $this;
+    }
+
+    /**
+     * Get the current colour gain factor.
+     *
+     * @return float
+     */
+    public function getGain()
+    {
+        return $this->gain;
+    }
+
+    /**
+     * Turn the graph legends (axes and scales) on and off.
+     *
+     * @param bool $legend
+     *
+     * @return $this
+     */
+    public function setLegend($legend = true)
+    {
+        $this->legend = (bool)$legend;
+
+        return $this;
+    }
+
+    /**
+     * Get the current legend state.
+     *
+     * @return bool
+     */
+    public function getLegend()
+    {
+        return $this->legend;
+    }
+
+    /**
+     * Set the color rotation value. This rotates the colour palette, not the resulting image.
+     *
+     * @param float $rotation
+     *
+     * @return $this
+     */
+    public function setRotation($rotation = 0.0)
+    {
+        $rotation = (float)$rotation;
+        if ($rotation < -1.0 || $rotation > 1.0) {
+            throw new InvalidArgumentException('Color rotation must be between -1.0 and 1.0.');
+        }
+        $this->rotation = $rotation;
+
+        return $this;
+    }
+
+    /**
+     * Get the color palette rotation value.
+     *
+     * @return float
+     */
+    public function getRotation()
+    {
+        return $this->rotation;
+    }
+
+    /**
+     * Set the starting frequency for the spectrum.
+     *
+     * @param int $start The starting frequency, in Hz. Must be positive and not greater than the stop frequency.
+     *
+     * @return $this
+     */
+    public function setStart($start = 0)
+    {
+        $start = (int)abs($start);
+        if ($start > $this->stop) {
+            throw new InvalidArgumentException('Start frequency must be lower than stop frequency.');
+        }
+        $this->start = $start;
+
+        return $this;
+    }
+
+    /**
+     * Get the current starting frequency.
+     *
+     * @return int
+     */
+    public function getStart()
+    {
+        return $this->start;
+    }
+
+    /**
+     * Set the ending frequency for the spectrum.
+     *
+     * @param int $stop The ending frequency, in Hz. Must be positive and not less than the start frequency.
+     *
+     * @return $this
+     */
+    public function setStop($stop = 0)
+    {
+        $stop = (int)abs($stop);
+        if ($stop < $this->start) {
+            throw new InvalidArgumentException('Stop frequency must be higher than start frequency.');
+        }
+        $this->stop = $stop;
+
+        return $this;
+    }
+
+    /**
+     * Get the current ending frequency.
+     *
+     * @return int
+     */
+    public function getStop()
+    {
+        return $this->stop;
+    }
+
+    /**
+     * Compile options into a parameter string
+     *
+     * @return string
+     */
+    protected function compileOptions()
+    {
+        $params = array();
+        $params[] = 's=' . $this->width . 'x' . $this->height;
+        if ($this->mode !== self::DEFAULT_MODE) {
+            $params[] = 'mode=' . $this->mode;
+        }
+        if ($this->color !== self::DEFAULT_COLOR) {
+            $params[] = 'color=' . $this->color;
+        }
+        if ($this->scale !== self::DEFAULT_SCALE) {
+            $params[] = 'scale=' . $this->scale;
+        }
+        if ($this->fscale !== self::DEFAULT_FSCALE) {
+            $params[] = 'fscale=' . $this->fscale;
+        }
+        if ($this->saturation !== self::DEFAULT_SATURATION) {
+            $params[] = 'saturation=' . $this->saturation;
+        }
+        if ($this->win_func !== self::DEFAULT_WIN_FUNC) {
+            $params[] = 'win_func=' . $this->win_func;
+        }
+        if ($this->orientation !== self::DEFAULT_ORIENTATION) {
+            $params[] = 'orientation=' . $this->orientation;
+        }
+        if ($this->gain !== self::DEFAULT_GAIN) {
+            $params[] = 'gain=' . $this->gain;
+        }
+        if ($this->legend !== self::DEFAULT_LEGEND) {
+            $params[] = 'legend=' . ($this->legend ? '1' : '0');
+        }
+        if ($this->rotation !== self::DEFAULT_ROTATION) {
+            $params[] = 'rotation=' . $this->rotation;
+        }
+        if ($this->start !== self::DEFAULT_START) {
+            $params[] = 'start=' . $this->start;
+        }
+        if ($this->stop !== self::DEFAULT_STOP) {
+            $params[] = 'stop=' . $this->stop;
+        }
+        return implode(':', $params);
+    }
+
+    /**
+     * Generates and saves the spectrum in the given filename.
+     *
+     * @param string $pathfile
+     *
+     * @return Spectrum
+     *
+     * @throws RuntimeException
+     */
+    public function save($pathfile)
+    {
+        /**
+         * might be optimized with http://ffmpeg.org/trac/ffmpeg/wiki/Seeking%20with%20FFmpeg
+         * @see http://ffmpeg.org/ffmpeg.html#Main-options
+         */
+        $commands = array(
+            '-y', //Overwrite output files
+            '-i', //Specify input file
+            $this->pathfile,
+            '-filter_complex', //Say we want a complex filter
+            'showspectrumpic=' . $this->compileOptions(), //Specify the filter and its params
+            '-frames:v', //Stop writing output...
+            1 // after 1 "frame"
+        );
+
+        foreach ($this->filters as $filter) {
+            $commands = array_merge($commands, $filter->apply($this));
+        }
+
+        $commands = array_merge($commands, array($pathfile));
+
+        try {
+            $this->driver->command($commands);
+        } catch (ExecutionFailureException $e) {
+            $this->cleanupTemporaryFile($pathfile);
+            throw new RuntimeException('Unable to save spectrum', $e->getCode(), $e);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Functional/AudioImagingTest.php
+++ b/tests/Functional/AudioImagingTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\FFMpeg\Functional;
+
+use FFMpeg\FFMpeg;
+use FFMpeg\FFProbe;
+use FFMpeg\Media\Spectrum;
+
+class AudioImagingTest extends FunctionalTestCase
+{
+    /**
+     * Path prefix to avoid conflicts with another tests.
+     */
+    const OUTPUT_PATH_PREFIX = 'output/audio_';
+
+    public function testgenerateSpectrumImage()
+    {
+        $ffmpeg = FFMpeg::create();
+        $ffprobe = FFProbe::create();
+        $audio = $ffmpeg->open(realpath(__DIR__ . '/../files/Audio.mp3'));
+        $spectrum = new Spectrum($audio, $ffmpeg->getFFMpegDriver(), $ffprobe, 1024, 1024);
+        $spectrum->setLegend(false)
+            ->setOrientation('horizontal')
+            ->setColor('fiery');
+        $output = __DIR__ . '/' . self::OUTPUT_PATH_PREFIX . 'spectrum.png';
+        $spectrum->save($output);
+        $this->assertFileExists($output);
+        unlink($output);
+    }
+}

--- a/tests/Unit/FFProbe/OptionsTesterTest.php
+++ b/tests/Unit/FFProbe/OptionsTesterTest.php
@@ -77,13 +77,11 @@ class OptionsTesterTest extends TestCase
             ->method('fetch')
             ->will($this->returnValue($data));
 
-        $cache->expects($this->at(0))
+        $cache->expects($this->exactly(2))
             ->method('contains')
-            ->will($this->returnValue(false));
-
-        $cache->expects($this->at(1))
-            ->method('contains')
-            ->will($this->returnValue(true));
+            ->willReturnOnConsecutiveCalls(
+                $this->returnValue(false),
+                $this->returnValue(true));
 
         $cache->expects($this->once())
             ->method('save');

--- a/tests/Unit/Media/SpectrumTest.php
+++ b/tests/Unit/Media/SpectrumTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Media;
+
+use FFMpeg\Media\Spectrum;
+
+class SpectrumTest extends AbstractMediaTestCase
+{
+
+    /**
+     * @dataProvider provideSaveOptions
+     */
+    public function testSave($commands)
+    {
+        $driver = $this->getFFMpegDriverMock();
+        $ffprobe = $this->getFFProbeMock();
+
+        $pathfile = '/tests/files/Audio.mp3';
+
+        array_push($commands, $pathfile);
+
+        $driver->expects($this->once())
+            ->method('command')
+            ->with($commands);
+
+        $spectrum = new Spectrum($this->getAudioMock(), $driver, $ffprobe, 640, 120);
+        $this->assertSame($spectrum, $spectrum->save($pathfile));
+    }
+
+    public function provideSaveOptions()
+    {
+        return array(
+            array(
+                array(
+                    '-y', '-i', NULL, '-filter_complex',
+                    'showspectrumpic=s=640x120',
+                    '-frames:v', '1',
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #770
| License            | MIT

#### What's in this PR?

This PR implements the ability to generate spectrogram images from audio input using [ffmpeg's `showspectrumpic` filter](https://ffmpeg.org/ffmpeg-filters.html#showspectrumpic), and provides a wrapper implementing all of that command's options, including full parameter validation. Unit and functional tests are included, along with sufficient phpdocs to make generated documentation readable.

#### Why?

The FFMpeg library already supports creating waveform images from audio, and this is a partner for that. As well as providing useful analytical information, it's good for generating thumbnails and icons for audio files, and the results are generally more interesting and colourful than the waveform output. Here's an example:

![audio_spectrum](https://user-images.githubusercontent.com/81561/98804159-19765d00-2416-11eb-9e9b-5fd82bdb9a46.png)

#### Example Usage

```php
        $ffmpeg = FFMpeg::create();
        $ffprobe = FFProbe::create();
        $audio = $ffmpeg->open(__DIR__ . '/files/Audio.mp3'));
        $spectrum = new Spectrum($audio, $ffmpeg->getFFMpegDriver(), $ffprobe, 1024, 1024);
        $spectrum->setLegend(false)
            ->setOrientation('horizontal')
            ->setColor('fiery');
        $spectrum->save(__DIR__ . '/output/spectrum.png');
```
#### BC Breaks/Deprecations

None

### Notes
I built this as an extension to the existing Waveform class since it has much in common with it, and that avoided duplicating all the filter support. The only real downside is that the `$colors` parameter on the constructor is ignored. The spectrum options are far more numerous than those for waveform, so I implemented fluent setters and getters for them.

I had some trouble with runnign tests because by default the test env picks up `avconv` instead of `ffmpeg` as the ffmpeg binary, and avconv does not support the `showspectrumpic` filter, however, if the ffmpeg binary path is set correctly in config, it works fine - but I don't see how to set that in the default test env.