### PR TITLE
Fix boolean types

### DIFF
--- a/src/FFMpeg/Coordinate/AspectRatio.php
+++ b/src/FFMpeg/Coordinate/AspectRatio.php
@@ -142,7 +142,7 @@ class AspectRatio
      * custom ratio need to be used, disable it.
      *
      * @param Dimension $dimension
-     * @param Boolean   $forceStandards Whether to force or not standard ratios
+     * @param bool   $forceStandards Whether to force or not standard ratios
      *
      * @return AspectRatio
      *

--- a/src/FFMpeg/FFProbe/DataMapping/AbstractData.php
+++ b/src/FFMpeg/FFProbe/DataMapping/AbstractData.php
@@ -24,7 +24,7 @@ abstract class AbstractData implements \Countable
      * Returns true if data has property.
      *
      * @param  string  $property
-     * @return Boolean
+     * @return bool
      */
     public function has($property)
     {

--- a/src/FFMpeg/FFProbe/DataMapping/Stream.php
+++ b/src/FFMpeg/FFProbe/DataMapping/Stream.php
@@ -20,7 +20,7 @@ class Stream extends AbstractData
     /**
      * Returns true if the stream is an audio stream.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isAudio()
     {
@@ -30,7 +30,7 @@ class Stream extends AbstractData
     /**
      * Returns true if the stream is a video stream.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isVideo()
     {

--- a/src/FFMpeg/FFProbe/OptionsTester.php
+++ b/src/FFMpeg/FFProbe/OptionsTester.php
@@ -42,7 +42,7 @@ class OptionsTester implements OptionsTesterInterface
 
         $output = $this->retrieveHelpOutput();
 
-        $ret = (Boolean) preg_match('/^'.$name.'/m', $output);
+        $ret = (bool) preg_match('/^'.$name.'/m', $output);
 
         $this->cache->save($id, $ret);
 

--- a/src/FFMpeg/FFProbe/OptionsTesterInterface.php
+++ b/src/FFMpeg/FFProbe/OptionsTesterInterface.php
@@ -18,7 +18,7 @@ interface OptionsTesterInterface
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return bool
      */
     public function has($name);
 }

--- a/src/FFMpeg/Filters/Video/ResizeFilter.php
+++ b/src/FFMpeg/Filters/Video/ResizeFilter.php
@@ -31,7 +31,7 @@ class ResizeFilter implements VideoFilterInterface
     private $dimension;
     /** @var string */
     private $mode;
-    /** @var Boolean */
+    /** @var bool */
     private $forceStandards;
     /** @var integer */
     private $priority;
@@ -69,7 +69,7 @@ class ResizeFilter implements VideoFilterInterface
     }
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function areStandardsForced()
     {

--- a/src/FFMpeg/Filters/Video/VideoFilters.php
+++ b/src/FFMpeg/Filters/Video/VideoFilters.php
@@ -31,7 +31,7 @@ class VideoFilters extends AudioFilters
      *
      * @param Dimension $dimension
      * @param string    $mode
-     * @param Boolean   $forceStandards
+     * @param bool   $forceStandards
      *
      * @return VideoFilters
      */

--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -42,7 +42,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
     /** @var string */
     private $pathfile;
 
-    /** @var Boolean */
+    /** @var bool */
     private $initialized = false;
 
     /** @var integer */

--- a/src/FFMpeg/Format/VideoInterface.php
+++ b/src/FFMpeg/Format/VideoInterface.php
@@ -44,7 +44,7 @@ interface VideoInterface extends AudioInterface
      *
      * @see https://wikipedia.org/wiki/Video_compression_picture_types
      *
-     * @return Boolean
+     * @return bool
      */
     public function supportBFrames();
 

--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -79,7 +79,7 @@ class Frame extends AbstractMediaType
      * Uses the `unaccurate method by default.`
      *
      * @param string  $pathfile
-     * @param Boolean $accurate
+     * @param bool $accurate
      *
      * @return Frame
      *


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | kind of, but no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | none
| Related issues/PRs | none
| License            | MIT

#### What's in this PR?

Some docblocks use Boolean as a type even though it should be `bool` and not an instance of Boolean class. This PR fixes this

#### Why?

I am fixing this because Psalm complains about an unknown type when using methods with this type:

```
ERROR: UndefinedDocblockClass - [...].php:37:14 - Docblock-defined class or interface FFMpeg\FFProbe\DataMapping\Boolean does not exist (see https://psalm.dev/200)
        if (!$format->has('duration')) {
```

