### PR TITLE
composer ... --prefer-dist now ignores dev files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 .gitignore export-ignore
 .github export-ignore
 docs export-ignore
+tests export-ignore
+phpunit.xml.dist export-ignore
+.travis.yml export-ignore


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | #710
| Related issues/PRs | #706 
| License            | MIT

#### What's in this PR?

the `tests` directory as well as `phpunit.xml.dist` and `travis.yml` files are no longer included in an archive of the project.

#### Why?

As explained in [this](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/) post, there is no need for developer oriented files within vendor folder in a another project. The author argues that this can speed up deployments.

#### Example Usage

Issuing the command:

```bash
composer require php-ffmpeg/php-ffmpeg --prefer-dist
```

should no longer include files that only concern developers of the library.

Thanks for this project! :)