### PR TITLE
Fix docs generation, PSR-12 type compliance

### DIFF
--- a/src/FFMpeg/Coordinate/Dimension.php
+++ b/src/FFMpeg/Coordinate/Dimension.php
@@ -22,8 +22,8 @@ class Dimension
     private $height;
 
     /**
-     * @param integer $width
-     * @param integer $height
+     * @param int $width
+     * @param int $height
      *
      * @throws InvalidArgumentException when one of the parameteres is invalid
      */
@@ -40,7 +40,7 @@ class Dimension
     /**
      * Returns width.
      *
-     * @return integer
+     * @return int
      */
     public function getWidth()
     {
@@ -50,7 +50,7 @@ class Dimension
     /**
      * Returns height.
      *
-     * @return integer
+     * @return int
      */
     public function getHeight()
     {
@@ -60,7 +60,7 @@ class Dimension
     /**
      * Returns the ratio.
      *
-     * @param type $forceStandards Whether or not force the use of standards ratios;
+     * @param bool $forceStandards Whether or not force the use of standards ratios;
      *
      * @return AspectRatio
      */

--- a/src/FFMpeg/Coordinate/Point.php
+++ b/src/FFMpeg/Coordinate/Point.php
@@ -28,7 +28,7 @@ class Point
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getX()
     {
@@ -36,7 +36,7 @@ class Point
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getY()
     {

--- a/src/FFMpeg/Filters/AdvancedMedia/ComplexFilterContainer.php
+++ b/src/FFMpeg/Filters/AdvancedMedia/ComplexFilterContainer.php
@@ -47,7 +47,7 @@ class ComplexFilterContainer implements ComplexFilterInterface
     /**
      * Returns the priority of the filter.
      *
-     * @return integer
+     * @return int
      */
     public function getPriority()
     {

--- a/src/FFMpeg/Filters/Audio/AudioResamplableFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioResamplableFilter.php
@@ -18,7 +18,7 @@ class AudioResamplableFilter implements AudioFilterInterface
 {
     /** @var string */
     private $rate;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     public function __construct($rate, $priority = 0)

--- a/src/FFMpeg/Filters/Audio/CustomFilter.php
+++ b/src/FFMpeg/Filters/Audio/CustomFilter.php
@@ -17,7 +17,7 @@ class CustomFilter implements AudioFilterInterface
 {
     /** @var string */
     private $filter;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     /**

--- a/src/FFMpeg/Filters/FilterInterface.php
+++ b/src/FFMpeg/Filters/FilterInterface.php
@@ -16,7 +16,7 @@ interface FilterInterface
     /**
      * Returns the priority of the filter.
      *
-     * @return integer
+     * @return int
      */
     public function getPriority();
 }

--- a/src/FFMpeg/Filters/Frame/CustomFrameFilter.php
+++ b/src/FFMpeg/Filters/Frame/CustomFrameFilter.php
@@ -18,7 +18,7 @@ class CustomFrameFilter implements FrameFilterInterface
 {
     /** @var string */
     private $filter;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     /**

--- a/src/FFMpeg/Filters/Frame/DisplayRatioFixerFilter.php
+++ b/src/FFMpeg/Filters/Frame/DisplayRatioFixerFilter.php
@@ -16,7 +16,7 @@ use FFMpeg\Media\Frame;
 
 class DisplayRatioFixerFilter implements FrameFilterInterface
 {
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     public function __construct($priority = 0)

--- a/src/FFMpeg/Filters/Video/ClipFilter.php
+++ b/src/FFMpeg/Filters/Video/ClipFilter.php
@@ -21,7 +21,7 @@ class ClipFilter implements VideoFilterInterface
     private $start;
     /** @var TimeCode */
     private $duration;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0)

--- a/src/FFMpeg/Filters/Video/CropFilter.php
+++ b/src/FFMpeg/Filters/Video/CropFilter.php
@@ -17,7 +17,7 @@ use FFMpeg\Media\Video;
 
 class CropFilter implements VideoFilterInterface
 {
-    /** @var integer */
+    /** @var int */
     protected $priority;
     /** @var Dimension */
     protected $dimension;

--- a/src/FFMpeg/Filters/Video/CustomFilter.php
+++ b/src/FFMpeg/Filters/Video/CustomFilter.php
@@ -17,7 +17,7 @@ class CustomFilter implements VideoFilterInterface
 {
     /** @var string */
     private $filter;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     /**

--- a/src/FFMpeg/Filters/Video/PadFilter.php
+++ b/src/FFMpeg/Filters/Video/PadFilter.php
@@ -21,7 +21,7 @@ class PadFilter implements VideoFilterInterface, ComplexCompatibleFilter
 {
     /** @var Dimension */
     private $dimension;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     public function __construct(Dimension $dimension, $priority = 0)

--- a/src/FFMpeg/Filters/Video/ResizeFilter.php
+++ b/src/FFMpeg/Filters/Video/ResizeFilter.php
@@ -33,7 +33,7 @@ class ResizeFilter implements VideoFilterInterface
     private $mode;
     /** @var bool */
     private $forceStandards;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     public function __construct(Dimension $dimension, $mode = self::RESIZEMODE_FIT, $forceStandards = true, $priority = 0)

--- a/src/FFMpeg/Filters/Video/RotateFilter.php
+++ b/src/FFMpeg/Filters/Video/RotateFilter.php
@@ -24,7 +24,7 @@ class RotateFilter implements VideoFilterInterface
 
     /** @var string */
     private $angle;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     public function __construct($angle, $priority = 0)

--- a/src/FFMpeg/Filters/Video/WatermarkFilter.php
+++ b/src/FFMpeg/Filters/Video/WatermarkFilter.php
@@ -23,7 +23,7 @@ class WatermarkFilter implements VideoFilterInterface, ComplexCompatibleFilter
     private $watermarkPath;
     /** @var array */
     private $coordinates;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     public function __construct($watermarkPath, array $coordinates = array(), $priority = 0)

--- a/src/FFMpeg/Filters/Waveform/WaveformDownmixFilter.php
+++ b/src/FFMpeg/Filters/Waveform/WaveformDownmixFilter.php
@@ -17,9 +17,9 @@ use FFMpeg\Media\Waveform;
 class WaveformDownmixFilter implements WaveformFilterInterface
 {
 
-    /** @var boolean */
+    /** @var bool */
     private $downmix;
-    /** @var integer */
+    /** @var int */
     private $priority;
 
     // By default, the downmix value is set to FALSE.

--- a/src/FFMpeg/Format/Audio/DefaultAudio.php
+++ b/src/FFMpeg/Format/Audio/DefaultAudio.php
@@ -24,10 +24,10 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     /** @var string */
     protected $audioCodec;
 
-    /** @var integer */
+    /** @var int */
     protected $audioKiloBitrate = 128;
 
-    /** @var integer */
+    /** @var int */
     protected $audioChannels = null;
 
     /**
@@ -79,7 +79,7 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     /**
      * Sets the kiloBitrate value.
      *
-     * @param  integer                  $kiloBitrate
+     * @param  int                  $kiloBitrate
      * @throws InvalidArgumentException
      */
     public function setAudioKiloBitrate($kiloBitrate)
@@ -104,7 +104,7 @@ abstract class DefaultAudio extends EventEmitter implements AudioInterface, Prog
     /**
      * Sets the channels value.
      *
-     * @param  integer                  $channels
+     * @param  int                  $channels
      * @throws InvalidArgumentException
      */
     public function setAudioChannels($channels)

--- a/src/FFMpeg/Format/AudioInterface.php
+++ b/src/FFMpeg/Format/AudioInterface.php
@@ -15,14 +15,14 @@ interface AudioInterface extends FormatInterface
     /**
      * Gets the audio kiloBitrate value.
      *
-     * @return integer
+     * @return int
      */
     public function getAudioKiloBitrate();
 
     /**
      * Gets the audio channels value.
      *
-     * @return integer
+     * @return int
      */
     public function getAudioChannels();
 

--- a/src/FFMpeg/Format/FormatInterface.php
+++ b/src/FFMpeg/Format/FormatInterface.php
@@ -22,7 +22,7 @@ interface FormatInterface
     /**
      * Returns an array of extra parameters to add to ffmpeg commandline.
      *
-     * @return array()
+     * @return array
      */
     public function getExtraParams();
 }

--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -21,16 +21,16 @@ use FFMpeg\Exception\RuntimeException;
  */
 abstract class AbstractProgressListener extends EventEmitter implements ListenerInterface
 {
-    /** @var integer */
+    /** @var int */
     private $duration;
 
-    /** @var integer */
+    /** @var int */
     private $totalSize;
 
-    /** @var integer */
+    /** @var int */
     private $currentSize;
 
-    /** @var integer */
+    /** @var int */
     private $currentTime;
 
     /** @var double */
@@ -45,30 +45,30 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
     /** @var bool */
     private $initialized = false;
 
-    /** @var integer */
+    /** @var int */
     private $currentPass;
 
-    /** @var integer */
+    /** @var int */
     private $totalPass;
 
     /**
      * Transcoding rate in kb/s
      *
-     * @var integer
+     * @var int
      */
     private $rate;
 
     /**
      * Percentage of transcoding progress (0 - 100)
      *
-     * @var integer
+     * @var int
      */
     private $percent = 0;
 
     /**
      * Time remaining (seconds)
      *
-     * @var integer
+     * @var int
      */
     private $remaining = null;
 
@@ -105,7 +105,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getCurrentPass()
     {
@@ -113,7 +113,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getTotalPass()
     {

--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -74,11 +74,10 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
 
     /**
      * @param FFProbe $ffprobe
-     * @param string  $pathfile
-     * @param integer $currentPass The cureent pass number
-     * @param integer $totalPass   The total number of passes
-     *
-     * @throws RuntimeException
+     * @param string $pathfile
+     * @param int $currentPass The current pass number
+     * @param int $totalPass The total number of passes
+     * @param int $duration
      */
     public function __construct(FFProbe $ffprobe, $pathfile, $currentPass, $totalPass, $duration = 0)
     {

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -49,7 +49,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     /**
      * Sets the kiloBitrate value.
      *
-     * @param  integer                  $kiloBitrate
+     * @param  int                  $kiloBitrate
      * @throws InvalidArgumentException
      */
     public function setKiloBitrate($kiloBitrate)
@@ -93,7 +93,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getModulus()
     {

--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -16,10 +16,10 @@ namespace FFMpeg\Format\Video;
  */
 class X264 extends DefaultVideo
 {
-    /** @var boolean */
+    /** @var bool */
     private $bframesSupport = true;
 
-    /** @var integer */
+    /** @var int */
     private $passes = 2;
 
     public function __construct($audioCodec = 'libfaac', $videoCodec = 'libx264')

--- a/src/FFMpeg/Format/VideoInterface.php
+++ b/src/FFMpeg/Format/VideoInterface.php
@@ -16,7 +16,7 @@ interface VideoInterface extends AudioInterface
     /**
      * Gets the kiloBitrate value.
      *
-     * @return integer
+     * @return int
      */
     public function getKiloBitrate();
 
@@ -28,7 +28,7 @@ interface VideoInterface extends AudioInterface
      *
      * @see http://www.undeadborn.net/tools/rescalculator.php
      *
-     * @return integer
+     * @return int
      */
     public function getModulus();
 

--- a/src/FFMpeg/Media/Audio.php
+++ b/src/FFMpeg/Media/Audio.php
@@ -130,8 +130,8 @@ class Audio extends AbstractStreamableMedia
     /**
      * Gets the waveform of the video.
      *
-     * @param  integer $width
-     * @param  integer $height
+     * @param  int $width
+     * @param  int $height
      * @param array $colors Array of colors for ffmpeg to use. Color format is #000000 (RGB hex string with #)
      * @return Waveform
      */

--- a/src/FFMpeg/Media/Clip.php
+++ b/src/FFMpeg/Media/Clip.php
@@ -35,7 +35,6 @@ class Clip extends Video
     /**
      * Returns the video related to the frame.
      *
-     * @param FormatInterface $format
      * @return Video
      */
     public function getVideo()

--- a/src/FFMpeg/Media/Concat.php
+++ b/src/FFMpeg/Media/Concat.php
@@ -156,11 +156,10 @@ class Concat extends AbstractMediaType
     /**
      * Saves the concatenated video in the given filename, considering that the sources videos are all encoded with the same codec.
      *
-     * @param string  $outputPathfile
+     * @param FormatInterface $format
+     * @param string $outputPathfile
      *
      * @return Concat
-     *
-     * @throws RuntimeException
      */
     public function saveFromDifferentCodecs(FormatInterface $format, $outputPathfile)
     {

--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -78,8 +78,9 @@ class Frame extends AbstractMediaType
      *
      * Uses the `unaccurate method by default.`
      *
-     * @param string  $pathfile
+     * @param string $pathfile
      * @param bool $accurate
+     * @param bool $returnBase64
      *
      * @return Frame
      *

--- a/src/FFMpeg/Media/Gif.php
+++ b/src/FFMpeg/Media/Gif.php
@@ -26,7 +26,7 @@ class Gif extends AbstractMediaType
     private $timecode;
     /** @var Dimension */
     private $dimension;
-    /** @var integer */
+    /** @var int */
     private $duration;
     /** @var Video */
     private $video;

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -31,7 +31,7 @@ class Video extends AbstractVideo
      *
      * @param  TimeCode $at
      * @param  Dimension $dimension
-     * @param  integer $duration
+     * @param  int $duration
      * @return Gif
      */
     public function gif(TimeCode $at, Dimension $dimension, $duration = null)


### PR DESCRIPTION
*This is a replacement for [an older PR](#776).*
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #774
| License            | MIT

#### What's in this PR?

Fixes all the errors reported when running the `generate-docs.sh` script. No code changes, only comments.

Standardises all `integer` and `boolean` type designators to unaliased `int` and `bool`, as per [PSR-12 section 2.5](https://www.php-fig.org/psr/psr-12/#25-keywords-and-types).