### PR TITLE
ExtractMultipleFrames filter generating excessively amount of images

### DIFF
--- a/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
+++ b/src/FFMpeg/Filters/Video/ExtractMultipleFramesFilter.php
@@ -133,7 +133,7 @@ class ExtractMultipleFramesFilter implements VideoFilterInterface
                 $nbDigitsInFileNames = "06";
 
             // Set the parameters
-            $commands[] = '-vf';
+            $commands[] = '-filter:v';
             $commands[] = 'fps=' . $this->frameRate;
             $commands[] = $this->destinationFolder . 'frame-%'.$nbDigitsInFileNames.'d.' . $this->frameFileType;
         }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #569
| Related issues/PRs | #569
| License            | MIT

#### What's in this PR?

As reported in the issue #569 ExtractMultipleFrames filter generate an excessive and incorrect amount of images, regardless of the chosen value.
For example: A mp4 video of 30 seconds with frameRate set to 1/10 generate 903 images instead of 3.

Basically the short syntax cause the issue to me, maybe it's a ffmpeg issue not related to this package?

Anyway....this PR fix that issue in my case. 
FFMPEG version  4.1.6.

Further investigation and tests welcome.

