### PR TITLE
Updated the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ Check another amazing repo: [PHP FFMpeg extras](https://github.com/alchemy-fr/PH
 
 ### How this library works:
 
-This library requires a working FFMpeg install. You will need both FFMpeg and FFProbe binaries to use it.
+This library requires a working [FFMpeg install](https://ffmpeg.org/download.html). You will need both FFMpeg and FFProbe binaries to use it.
 Be sure that these binaries can be located with system PATH to get the benefit of the binary detection,
 otherwise you should have to explicitly give the binaries path on load.
-
-For Windows users: Please find the binaries at http://ffmpeg.zeranoe.com/builds/.
 
 ### Known issues:
 


### PR DESCRIPTION
Removed a non-valid link to Windows build and added a link to the FFMPEG download page were all executables can be found.

| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #791
| Related issues/PRs | #791
| License            | MIT

#### What's in this PR?

A new link to download binaries.

#### Why?

README contained a link that was not valid anymore.