### PR TITLE
Add 'copy' as available video codec

### DIFF
--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -62,7 +62,7 @@ class X264 extends DefaultVideo
      */
     public function getAvailableVideoCodecs()
     {
-        return array('libx264');
+        return array('libx264', 'copy');
     }
 
     /**


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Adds copy as available video codec

#### Why?

Some video converted with libx264 lose quality

#### Example Usage

```php

// Now we can do
$format = new X264('aac', 'copy');

~~~
