### PR TITLE
Respect format KiloBitRate when using openAdvanced method & map

### DIFF
--- a/src/FFMpeg/Media/AdvancedMedia.php
+++ b/src/FFMpeg/Media/AdvancedMedia.php
@@ -259,6 +259,10 @@ class AdvancedMedia extends AbstractMediaType
                 $commands[] = '-vcodec';
                 $commands[] = $format->getVideoCodec();
             }
+            if ($format->getKiloBitrate() !== 0) {
+                $commands[] = '-b:v';
+                $commands[] = $format->getKiloBitrate() . 'k';
+            }
             // If the user passed some additional format parameters.
             if ($format->getAdditionalParameters() !== null) {
                 $commands = array_merge($commands, $format->getAdditionalParameters());


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

When using openAdvanced  method and then map method, the video format KiloBitrate is not added to the final command.


