### PR TITLE
Remove silex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,32 +714,6 @@ $ffprobe = FFMpeg\FFProbe::create();
 $ffprobe->isValid('/path/to/file/to/check'); // returns bool
 ```
 
-## Using with Silex Microframework
-
-The service provider is easy to set up:
-
-```php
-$app = new Silex\Application();
-$app->register(new FFMpeg\FFMpegServiceProvider());
-
-$video = $app['ffmpeg']->open('video.mpeg');
-```
-
-Available options are as follow:
-
-```php
-$app->register(new FFMpeg\FFMpegServiceProvider(), array(
-    'ffmpeg.configuration' => array(
-        'ffmpeg.threads'   => 4,
-        'ffmpeg.timeout'   => 300,
-        'ffmpeg.binaries'  => '/opt/local/ffmpeg/bin/ffmpeg',
-        'ffprobe.timeout'  => 30,
-        'ffprobe.binaries' => '/opt/local/ffmpeg/bin/ffprobe',
-    ),
-    'ffmpeg.logger' => $logger,
-));
-```
-
 ## License
 
 This project is licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"
     },
     "require-dev": {
-        "silex/silex": "~1.0",
         "symfony/phpunit-bridge": "^5.0.4",
         "symfony/process": "2.8 || 3.3"
     },

--- a/src/FFMpeg/FFMpegServiceProvider.php
+++ b/src/FFMpeg/FFMpegServiceProvider.php
@@ -15,6 +15,9 @@ use Doctrine\Common\Cache\ArrayCache;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
+/**
+ * @deprecated
+ */
 class FFMpegServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)

--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -10,7 +10,7 @@ class FFMpegServiceProviderTest extends TestCase
     protected function setUp()
     {
         if (!class_exists('\Application\Silex')) {
-            $this->markTestSkipped('You must have silex/silex installed.');
+            $this->markTestSkipped('You MUST have silex/silex installed.');
         }
     }
 

--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -7,6 +7,13 @@ use Silex\Application;
 
 class FFMpegServiceProviderTest extends TestCase
 {
+    protected function setUp()
+    {
+        if (!class_exists('\Application\Silex')) {
+            $this->markTestSkipped('You must have silex/silex installed.');
+        }
+    }
+
     public function testWithConfig()
     {
         $app = new Application();


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | yes
| Fixed tickets      | -
| Related issues/PRs | -
| License            | MIT

#### What's in this PR?

Remove Silex support.

#### Why?

Silex was abandoned 3 years ago, removing its support will allow to bump some dependencies.

#### BC Breaks/Deprecations

- `FFMpeg\FFMpegServiceProvider` was deprecated, the user must implement the provider by itself. 
