### PR TITLE
Add ffprobe configurations analyzeduration and probesize

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,8 @@ $app->register(new FFMpeg\FFMpegServiceProvider(), array(
         'ffmpeg.binaries'  => '/opt/local/ffmpeg/bin/ffmpeg',
         'ffprobe.timeout'  => 30,
         'ffprobe.binaries' => '/opt/local/ffmpeg/bin/ffprobe',
+        'ffprobe.analyzeduration' => 5000000000,
+        'ffprobe.probesize' => 1000000000,
     ),
     'ffmpeg.logger' => $logger,
 ));

--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -245,6 +245,31 @@ class FFProbe
 
         $parseIsToDo = false;
 
+        $config = $this->getFFProbeDriver()->getConfiguration();
+
+        if ($config && $config->has('ffprobe.analyzeduration')) {
+            if (!$this->optionsTester->has('\s*-analyzeduration')) {
+                throw new RuntimeException(
+                    'This version of ffprobe is too old and '
+                    . 'does not support `-analyzeduration` option, please upgrade'
+                );
+            }
+
+            $commands[] = '-analyzeduration';
+            $commands[] = $config->get('ffprobe.analyzeduration');
+        }
+        if ($config && $config->has('ffprobe.probesize')) {
+            if (!$this->optionsTester->has('\s*-probesize')) {
+                throw new RuntimeException(
+                    'This version of ffprobe is too old and '
+                    . 'does not support `-probesize` option, please upgrade'
+                );
+            }
+
+            $commands[] = '-probesize';
+            $commands[] = $config->get('ffprobe.probesize');
+        }
+
         if ($allowJson && $this->optionsTester->has('-print_format')) {
             // allowed in latest PHP-FFmpeg version
             $commands[] = '-print_format';

--- a/tests/Functional/FFProbeTest.php
+++ b/tests/Functional/FFProbeTest.php
@@ -38,4 +38,13 @@ class FFProbeTest extends FunctionalTestCase
         $ffprobe = FFProbe::create();
         $this->assertGreaterThan(0, count($ffprobe->streams('http://vjs.zencdn.net/v/oceans.mp4')));
     }
+
+    public function testLongProbeOnFile()
+    {
+        $ffprobe = FFProbe::create(array(
+            'analyzeduration' => 5000000000,
+            'probesize' => 1000000000,
+        ));
+        $this->assertGreaterThan(0, count($ffprobe->streams(__DIR__ . '/../files/Audio.mp3')));
+    }
 }

--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -15,6 +15,8 @@ class FFMpegServiceProviderTest extends TestCase
                 'ffmpeg.threads'   => 12,
                 'ffmpeg.timeout'   => 10666,
                 'ffprobe.timeout'  => 4242,
+                'ffprobe.analyzeduration' => 5000000000,
+                'ffprobe.probesize' => 1000000000,
             )
         ));
 
@@ -25,6 +27,8 @@ class FFMpegServiceProviderTest extends TestCase
         $this->assertEquals(12, $app['ffmpeg']->getFFMpegDriver()->getConfiguration()->get('ffmpeg.threads'));
         $this->assertEquals(10666, $app['ffmpeg']->getFFMpegDriver()->getProcessBuilderFactory()->getTimeout());
         $this->assertEquals(4242, $app['ffmpeg.ffprobe']->getFFProbeDriver()->getProcessBuilderFactory()->getTimeout());
+        $this->assertEquals(5000000000, $app['ffmpeg.ffprobe']->getFFProbeDriver()->getConfiguration()->get('ffprobe.analyzeduration'));
+        $this->assertEquals(1000000000, $app['ffmpeg.ffprobe']->getFFProbeDriver()->getConfiguration()->get('ffprobe.probesize'));
     }
 
     public function testWithoutConfig()

--- a/tests/Unit/FFProbeTest.php
+++ b/tests/Unit/FFProbeTest.php
@@ -123,6 +123,77 @@ class FFProbeTest extends TestCase
         $this->assertEquals($output, call_user_func(array($ffprobe, $method), $pathfile));
     }
 
+    public function provideDataWithAnalyzeOptions()
+    {
+        $stream = $this->getStreamMock();
+        $format = $this->getFormatMock();
+
+        return array(
+            array($stream, 'streams', array('-show_streams', '\s*-analyzeduration', '\s*-probesize'), FFProbe::TYPE_STREAMS, array(__FILE__, '-show_streams', '-analyzeduration', 5000000000, '-probesize', 1000000000)),
+            array($format, 'format', array('-show_format', '\s*-analyzeduration', '\s*-probesize'), FFProbe::TYPE_FORMAT, array(__FILE__, '-show_format', '-analyzeduration', 5000000000, '-probesize', 1000000000)),
+        );
+    }
+
+    /**
+     * @dataProvider provideDataWithAnalyzeOptions
+     */
+    public function testProbeWithAnalyzeOptions($output, $method, $commands, $type, $caughtCommands)
+    {
+        $pathfile = __FILE__;
+        $data = array('key' => 'value');
+        $rawData = 'raw data';
+        $conf = FFProbe::create(array(
+            'ffprobe.analyzeduration' => 5000000000,
+            'ffprobe.probesize' => 1000000000,
+        ))->getFFProbeDriver()->getConfiguration();
+
+        $this->assertTrue($conf->has('ffprobe.analyzeduration'));
+        $this->assertSame(1000000000, $conf->get('ffprobe.probesize'));
+
+        $ffprobe = new FFProbe($this->getFFProbeDriverMock(), $this->getCacheMock());
+
+        $mapper = $this->getFFProbeMapperMock();
+        $mapper->expects($this->once())
+            ->method('map')
+            ->with($type, $data)
+            ->will($this->returnValue($output));
+
+        $parser = $this->getFFProbeParserMock();
+        $parser->expects($this->once())
+            ->method('parse')
+            ->with($type, $rawData)
+            ->will($this->returnValue($data));
+
+        $tester = $this->getFFProbeOptionsTesterMockWithOptions($commands);
+
+        $cache = $this->getCacheMock();
+        $cache->expects($this->once())
+            ->method('contains')
+            ->will($this->returnValue(false));
+        $cache->expects($this->never())
+            ->method('fetch');
+        $cache->expects($this->once())
+            ->method('save')
+            ->with($this->anything(), $output);
+
+        $driver = $this->getFFProbeDriverMock();
+        $driver->expects($this->once())
+            ->method('command')
+            ->with($caughtCommands)
+            ->willReturn($rawData);
+        $driver->expects($this->once())
+            ->method('getConfiguration')
+            ->willReturn($conf);
+
+        $ffprobe->setOptionsTester($tester)
+            ->setCache($cache)
+            ->setMapper($mapper)
+            ->setFFProbeDriver($driver)
+            ->setParser($parser);
+
+        $this->assertEquals($output, call_user_func(array($ffprobe, $method), $pathfile));
+    }
+
     public function provideDataForInvalidJson()
     {
         $stream = $this->getStreamMock();


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #825 
| Related issues/PRs | -
| License            | MIT

#### What's in this PR?

Add support of Ffprobe configuration to define an higher value of analyzeduration and probesize.
This is useful (at least in my case) to probe big file in a background process.

#### Why?

In my usecase, the video was properly encoded and work as expected, but Ffprobe is not able to recognize properly all streams (not listed, or no codec, no type retrieved)

#### Example Usage

```php
$ffprobe = FFProbe::create([
            'ffprobe.analyzeduration' => 5000000000,
            'ffprobe.probesize' => 1000000000,
        ]);
~~~

