### PR TITLE
'progress' -> $percent is a float now

### DIFF
--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -199,7 +199,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
 
         $percent = $percent / $this->totalPass + ($this->currentPass - 1) / $this->totalPass;
 
-        $this->percent = floor($percent * 100);
+        $this->percent = round($percent * 100, 2, PHP_ROUND_HALF_DOWN);
         $this->lastOutput = $currentTime;
         $this->currentSize = (int) $currentSize;
         $this->currentTime = $currentDuration;


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #622 
| Related issues/PRs | #622 
| License            | MIT

#### What's in this PR?

This PR makes the `$percent` parameter in the `progress` event a floating value instead of an integer, up to two decimal points.

Credit for this PR's concept & code should go to [sevildevil1990](https://github.com/sevildevil1990) for coming up with it in this [issue](https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues/622).

#### Why?

This increases the precision of your progress update.

#### Example Usage

```php
$format = new FFMpeg\Format\Video\X264();
$format->on('progress', function ($video, $format, $percentage) {
    // $percentage might say 25.01% instead of just 25%
    echo "$percentage % transcoded...\n";
});
~~~
