### PR TITLE
Drop support for PHP < 7.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,4 +44,4 @@ jobs:
         uses: FedericoCarboni/setup-ffmpeg@v1
 
       - name: Run tests
-        run: ./phpunit --verbose
+        run: ./vendor/bin/phpunit --verbose

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,18 +13,12 @@ jobs:
     name: "PHP ${{ matrix.php-version }} ${{ matrix.dependency-versions }} ${{ matrix.composer-stability }}"
     runs-on: ubuntu-latest
 
-    env:
-      PHPUNIT_VERSION: ${{ matrix.phpunit-version }}
-
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        php-version: [8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5]
+        php-version: [8.1, 8.0, 7.4]
         dependency-versions: [prefer-lowest, prefer-stable]
-        include:
-          - php-version: 5.5
-            phpunit-version: 4
 
     steps:
       - name: Checkout project
@@ -36,14 +30,6 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
           coverage: none
-
-      - name: Install phpunit
-        if: ${{ matrix.phpunit-version }}
-        run: |
-          composer remove symfony/phpunit-bridge --dev
-          wget -O phpunit "https://phar.phpunit.de/phpunit-${{ matrix.phpunit-version }}.phar"
-          chmod +x phpunit
-          composer require "roave/security-advisories" dev-master --no-update
 
       - name: Set composer stability
         if: ${{ matrix.composer-stability }}
@@ -58,9 +44,4 @@ jobs:
         uses: FedericoCarboni/setup-ffmpeg@v1
 
       - name: Run tests
-        run: |
-          if [ "$PHPUNIT_VERSION" ]; then
-              ./phpunit --verbose
-          else
-              ./vendor/bin/simple-phpunit --verbose
-          fi;
+        run: ./phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,16 @@
     "name": "php-ffmpeg/php-ffmpeg",
     "type": "library",
     "description": "FFMpeg PHP, an Object Oriented library to communicate with AVconv / ffmpeg",
-    "keywords": ["video processing", "video", "audio processing", "audio", "avconv", "ffmpeg", "avprobe", "ffprobe"],
+    "keywords": [
+        "video processing",
+        "video",
+        "audio processing",
+        "audio",
+        "avconv",
+        "ffmpeg",
+        "avprobe",
+        "ffprobe"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -32,18 +41,17 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "alchemy/binary-driver": "^1.5 || ~2.0.0 || ^5.0",
-        "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "neutron/temporary-filesystem": "^2.1.1 || ^3.0",
-        "symfony/cache": "^3.1 || ^4.0 || ^5.0 || ^6.0"
+        "php": "^7.4|^8.0",
+        "alchemy/binary-driver": "^5.0",
+        "evenement/evenement": "^1.0",
+        "neutron/temporary-filesystem": "^3.0",
+        "symfony/cache": "^5.0 || ^6.0"
     },
     "suggest": {
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0.4",
-        "symfony/process": "2.8 || 3.3"
+        "phpunit/phpunit": "^9.4"
     },
     "autoload": {
         "psr-0": {

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -4,60 +4,10 @@ namespace Tests\FFMpeg;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * This is a BC Layer to support phpunit 4.8 needed for php <= 5.5.
- */
-if (class_exists('PHPUnit_Runner_Version')
-    && version_compare(\PHPUnit_Runner_Version::id(), '5', '<')
-) {
-    class BaseTestCase extends TestCase
+class BaseTestCase extends TestCase
+{
+    public function assertScalar($value, $message = '')
     {
-        public static function assertScalar($value, $message = '')
-        {
-            self::assertTrue(is_scalar($value), $message);
-        }
-
-        public static function assertIsArray($value, $message = '')
-        {
-            self::assertTrue(is_array($value), $message);
-        }
-
-        public static function assertIsInt($value, $message = '')
-        {
-            self::assertTrue(is_int($value), $message);
-        }
-
-        public static function assertIsBool($value, $message = '')
-        {
-            self::assertTrue(is_bool($value), $message);
-        }
-
-        public static function assertIsString($value, $message = '')
-        {
-            self::assertTrue(is_string($value), $message);
-        }
-
-        public function expectException($exception, $message = null)
-        {
-            $this->setExpectedException($exception, $message);
-        }
-
-        public static function assertStringContainsString($needle, $haystack, $message = '')
-        {
-            self::assertContains($needle, $haystack, $message);
-        }
-
-        public static function assertStringNotContainsString($needle, $haystack, $message = '')
-        {
-            self::assertNotContains($needle, $haystack, $message);
-        }
-    }
-} else {
-    class BaseTestCase extends TestCase
-    {
-        public function assertScalar($value, $message = '')
-        {
-            $this->assertTrue(is_scalar($value), $message);
-        }
+        $this->assertTrue(is_scalar($value), $message);
     }
 }

--- a/tests/Unit/Driver/FFMpegDriverTest.php
+++ b/tests/Unit/Driver/FFMpegDriverTest.php
@@ -9,8 +9,10 @@ use Symfony\Component\Process\ExecutableFinder;
 
 class FFMpegDriverTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
+        parent::setUp();
+        
         $executableFinder = new ExecutableFinder();
 
         $found = false;

--- a/tests/Unit/Driver/FFProbeDriverTest.php
+++ b/tests/Unit/Driver/FFProbeDriverTest.php
@@ -9,8 +9,10 @@ use Symfony\Component\Process\ExecutableFinder;
 
 class FFProbeDriverTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
+        parent::setUp();
+        
         $executableFinder = new ExecutableFinder();
 
         $found = false;

--- a/tests/Unit/FFMpegServiceProviderTest.php
+++ b/tests/Unit/FFMpegServiceProviderTest.php
@@ -7,8 +7,10 @@ use Silex\Application;
 
 class FFMpegServiceProviderTest extends TestCase
 {
-    protected function setUp()
+    public function setUp(): void
     {
+        parent::setUp();
+        
         if (!class_exists('\Application\Silex')) {
             $this->markTestSkipped('You MUST have silex/silex installed.');
         }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | -
| Related issues/PRs | -
| License            | MIT

#### What's in this PR?

Drop support for anything below PHP 7.4

#### Why?

Get rid of unsupported PHP versions to improve the maintainability and development speed.