### PR TITLE
Use dev-master of evenement/evenement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     ],
     "require": {
         "php": "^8.0 || ^8.1",
-        "evenement/evenement": "^3.0",
+        "evenement/evenement": "dev-master",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",
         "symfony/process": "^5.4 || ^6.0",


### PR DESCRIPTION
The latest tagged version of evenement/evenement does not include the [forward](https://github.com/igorw/evenement/blob/master/src/Evenement/EventEmitterTrait.php#L211) method; `dev-master` has to be used instead to have it.