### PR TITLE
concat add parameter -y

### DIFF
--- a/src/FFMpeg/Media/Concat.php
+++ b/src/FFMpeg/Media/Concat.php
@@ -118,6 +118,7 @@ class Concat extends AbstractMediaType
         $commands = [
             '-f', 'concat', '-safe', '0',
             '-i', $sourcesFile,
+            '-y',
         ];
 
         // Check if stream copy is activated
@@ -171,7 +172,9 @@ class Concat extends AbstractMediaType
         }
 
         // Create the commands variable
-        $commands = [];
+        $commands = [
+            '-y',
+        ];
 
         // Prepare the parameters
         $nbSources = 0;


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

adds parameter -y to overwrite the file.

#### Why?

The [concatenation](https://github.com/PHP-FFMpeg/PHP-FFMpeg#concatenation) does not work if the output file is already exists.


