### PR TITLE
Add Audio Sample Format Filter

### DIFF
--- a/src/FFMpeg/Filters/Audio/AudioSampleFormatFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioSampleFormatFilter.php
@@ -43,4 +43,9 @@ class AudioSampleFormatFilter implements AudioFilterInterface
     {
         return $this->priority;
     }
+
+    public function getFormat()
+    {
+        return $this->format;
+    }
 }

--- a/src/FFMpeg/Filters/Audio/AudioSampleFormatFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioSampleFormatFilter.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * This file is part of PHP-FFmpeg.
+ *
+ * (c) Dr Pshtiwan <drpshtiwan@thejano.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Add a filter to change the sample format of the audio, to see the available formats
+ * run ffmpeg -sample_fmts
+ */
+
+namespace FFMpeg\Filters\Audio;
+
+use FFMpeg\Format\AudioInterface;
+use FFMpeg\Media\Audio;
+
+class AudioSampleFormatFilter implements AudioFilterInterface
+{
+    private string $format;
+
+    private int $priority;
+
+    public function __construct(string $format, $priority = 0)
+    {
+        $this->format = $format;
+        $this->priority = $priority;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function apply(Audio $audio, AudioInterface $format)
+    {
+        return ['-sample_fmt', $this->format];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+}

--- a/tests/FFMpeg/Unit/Filters/Audio/AudioSampleFormatFilterTest.php
+++ b/tests/FFMpeg/Unit/Filters/Audio/AudioSampleFormatFilterTest.php
@@ -3,14 +3,18 @@
 namespace Tests\FFMpeg\Unit\Filters\Audio;
 
 use FFMpeg\Filters\Audio\AudioSampleFormatFilter;
-use PHPUnit\Framework\TestCase;
+use Tests\FFMpeg\Unit\TestCase;
 
-class AudioSampleFormatFilterTest extends TestCase
+/**
+ * @internal
+ * @coversNothing
+ */
+final class AudioSampleFormatFilterTest extends TestCase
 {
-    public function testGetRate()
+    public function testGetFormat()
     {
         $filter = new AudioSampleFormatFilter('s16');
-        $this->assertEquals('s16', $filter->getRate());
+        static::assertSame('s16', $filter->getFormat());
     }
 
     public function testApply()
@@ -19,6 +23,6 @@ class AudioSampleFormatFilterTest extends TestCase
         $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
 
         $filter = new AudioSampleFormatFilter('s16');
-        $this->assertEquals(['-sample_fmt', 's16'], $filter->apply($audio, $format));
+        static::assertSame(['-sample_fmt', 's16'], $filter->apply($audio, $format));
     }
 }

--- a/tests/FFMpeg/Unit/Filters/Audio/AudioSampleFormatFilterTest.php
+++ b/tests/FFMpeg/Unit/Filters/Audio/AudioSampleFormatFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\FFMpeg\Unit\Filters\Audio;
+
+use FFMpeg\Filters\Audio\AudioSampleFormatFilter;
+use PHPUnit\Framework\TestCase;
+
+class AudioSampleFormatFilterTest extends TestCase
+{
+    public function testGetRate()
+    {
+        $filter = new AudioSampleFormatFilter('s16');
+        $this->assertEquals('s16', $filter->getRate());
+    }
+
+    public function testApply()
+    {
+        $audio = $this->getAudioMock();
+        $format = $this->getMockBuilder('FFMpeg\Format\AudioInterface')->getMock();
+
+        $filter = new AudioSampleFormatFilter('s16');
+        $this->assertEquals(['-sample_fmt', 's16'], $filter->apply($audio, $format));
+    }
+}


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?
This PR adds a Sample format filter to audio filters. Which allows changing bit depth of the given file, like 16-bit, 24-bit, 32-bit.. etc.

Allowed sample formats can be seen by running 
`ffmpeg -sample_fmts`



#### Why?
Converting bit depth (Sample format) is required to work with some audio files.

#### Example Usage

```php
$ffmpeg = FFMpeg\FFMpeg::create();

// Now we can do
$audio = $ffmpeg->open('pathToAnAudiofile');
$audio->addFilter(new FFMpeg\Filters\Audio\AudioSampleFormatFilter('s16')) 

// Assigning a format
$format = new FFMpeg\Format\Audio\Flac();

// Saving the audio
$audio->save($format, 'NewPathForSaving');
~~~


#### To Do

- [ ] Created AudioSampleFormatFilterTest unit tests
