### PR TITLE
allow audio codec to be set to "aac"

### DIFF
--- a/src/FFMpeg/Format/Audio/Aac.php
+++ b/src/FFMpeg/Format/Audio/Aac.php
@@ -26,6 +26,6 @@ class Aac extends DefaultAudio
      */
     public function getAvailableAudioCodecs()
     {
-        return ['libfdk_aac'];
+        return ['libfdk_aac', 'aac'];
     }
 }


### PR DESCRIPTION
this is the FFMPEG internal aac encoder.
libfdk_aac is not GPL compatible, and thuis not included in officlal and debian binaries.

| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | 
| Related issues/PRs | 
| License            | MIT

#### What's in this PR?
 added an encoder name  ("aac")to AAC audio format

#### Why?

libfdk_aac encoder is not available in debian's FFMPEG distribution
and actually we can't switch to default internal encoder "aac"

#### Example Usage

```php
$ffmpeg = FFMpeg\FFMpeg::create();
$audio = $ffmpeg->open("./audio.flac");
$codec = new FFMpeg\Format\Audio\Aac();
$codec->setAudioCodec("aac");
$audio->save($codec, "./audio.m4a");
```

