### PR TITLE
Why WebM does not work with opus?

### DIFF
--- a/src/FFMpeg/Format/Video/WebM.php
+++ b/src/FFMpeg/Format/Video/WebM.php
@@ -44,7 +44,7 @@ class WebM extends DefaultVideo
      */
     public function getAvailableAudioCodecs()
     {
-        return ['copy', 'libvorbis'];
+        return ['copy', 'libvorbis', 'libopus'];
     }
 
     /**


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Explain the contents of the PR.

Opus is a widely used codec for webm. Why cannot we take it to encode webm with the library?

#### Example Usage

```php

// Now we can do
$format = new FFMpeg\Format\Video\WebM("libopus");

