### PR TITLE
Add inputs parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,24 @@ $advancedMedia
     ->setAdditionalParameters(array('the', 'params', 'that', 'will', 'be', 'added', 'at', 'the', 'end', 'of', 'the', 'command'));
 ```
 
+##### Add inputs parameters
+If you need you can add extra parameters for each input of the AdvancedMedia:
+
+```php
+$inputs = [
+    'video_1.mp4',
+    'video_2.mp4',
+];
+$extraInputsParams = [
+    0 => ['-f', 'lavfi', '-t', '10'],          // extra params for firts input 'video_1.mp4' (key 0 in $inputs array)
+    1 => ['some', 'other', 'extra', 'params'], // extra params for third input 'video_2.mp4' (key 1 in $inputs array)
+];
+$advancedMedia = $ffmpeg->openAdvanced($inputs);
+$advancedMedia->setInputsParameters($extraInputsParams);
+```
+Final command will be looks like:
+`-f lavfi -t 10 -i /path/to/video_1.mp4 some other extra params -i /path/to/video_2.mp4`
+
 #### Formats
 
 A format implements `FFMpeg\Format\FormatInterface`. To save to a video file,

--- a/src/FFMpeg/Media/AdvancedMedia.php
+++ b/src/FFMpeg/Media/AdvancedMedia.php
@@ -40,6 +40,12 @@ class AdvancedMedia extends AbstractMediaType
      * @var string[]
      */
     private $additionalParameters;
+	
+	/**
+     *
+     * @var array[]
+     */
+    private $inputsParameters;
 
     /**
      * @var string[]
@@ -72,6 +78,7 @@ class AdvancedMedia extends AbstractMediaType
         $this->inputs = $inputs;
         $this->initialParameters = [];
         $this->additionalParameters = [];
+		$this->inputsParameters = [];
         $this->mapCommands = [];
         $this->listeners = [];
     }
@@ -154,6 +161,24 @@ class AdvancedMedia extends AbstractMediaType
 
         return $this;
     }
+	
+	/**
+     * @return array
+     */
+    public function getInputsParameters()
+    {
+        return $this->inputsParameters;
+    }
+
+    /**
+     * @param array $parameters
+     * @return AdvancedMedia
+     */
+    public function setInputsParameters(array $parameters)
+    {
+        $this->inputsParameters = $parameters;
+        return $this;
+    }
 
     /**
      * @return string[]
@@ -169,6 +194,25 @@ class AdvancedMedia extends AbstractMediaType
     public function getInputsCount()
     {
         return count($this->inputs);
+    }
+	
+	/**
+     * Add parameters to inputs
+     * 
+     * @param int $inputKey
+     * @return type
+     */
+    private function mapInput(int $inputKey)
+    {
+        $commands = array();
+
+        if (isset($this->inputsParameters[$inputKey])) {
+            foreach ($this->inputsParameters[$inputKey] as $param) {
+                $commands[] = $param;
+            }
+        }
+
+        return $commands;
     }
 
     /**
@@ -395,7 +439,8 @@ class AdvancedMedia extends AbstractMediaType
     private function buildInputsPart(array $inputs)
     {
         $commands = [];
-        foreach ($inputs as $input) {
+		foreach ($inputs as $key => $input) {
+			$commands = array_merge($commands, $this->mapInput($key));
             $commands[] = '-i';
             $commands[] = $input;
         }


### PR DESCRIPTION
##### Add inputs parameters
If you need you can add extra parameters for each input of the AdvancedMedia:

```php
$inputs = [
    'video_1.mp4',
    'video_2.mp4',
];
$extraInputsParams = [
    0 => ['-f', 'lavfi', '-t', '10'],          // extra params for firts input 'video_1.mp4' (key 0 in $inputs array)
    1 => ['some', 'other', 'extra', 'params'], // extra params for third input 'video_2.mp4' (key 1 in $inputs array)
];
$advancedMedia = $ffmpeg->openAdvanced($inputs);
$advancedMedia->setInputsParameters($extraInputsParams);
```
Final command will be looks like:
`-f lavfi -t 10 -i /path/to/video_1.mp4 some other extra params -i /path/to/video_2.mp4`