### PR TITLE
Fix type declaration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -37,7 +37,7 @@ jobs:
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ~/.composer/cache/files
                   key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}-dep-${{ matrix.dependency-version }}

--- a/src/Alchemy/BinaryDriver/Configuration.php
+++ b/src/Alchemy/BinaryDriver/Configuration.php
@@ -78,7 +78,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return $this->has($offset);
     }
@@ -86,7 +86,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->get($offset);
     }
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, $value): void
     {
         $this->set($offset, $value);
     }
@@ -102,7 +102,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         $this->remove($offset);
     }

--- a/src/Alchemy/BinaryDriver/ConfigurationInterface.php
+++ b/src/Alchemy/BinaryDriver/ConfigurationInterface.php
@@ -36,7 +36,7 @@ interface ConfigurationInterface extends \ArrayAccess, \IteratorAggregate
      *
      * @param string $key
      *
-     * @return Boolean
+     * @return boolean
      */
     public function has($key);
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #875
| Related issues/PRs | #875
| License            | MIT

#### What's in this PR?

Fix compatiblity with ArrayAccess

#### Why?

Return type of Alchemy\BinaryDriver\Configuration::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool