### PR TITLE
AbstractProgressListener: remove totalSize null check

### DIFF
--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -161,7 +161,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
             $this->initialize();
         }
 
-        if (null === $this->totalSize || null === $this->duration) {
+        if (null === $this->duration) {
             return;
         }
 
@@ -249,7 +249,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
             return;
         }
 
-        if (false === $format->has('size') || false === $format->has('duration')) {
+        if (false === $format->has('duration')) {
             return;
         }
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #794 
| Related issues/PRs | #794 
| License            | MIT

#### What's in this PR?

This PR removes the null check for `$this->totalSize` present in the `AbstractProgressListener` class. This validation isn't necessary for the whole progress-tracking mechanism to work and only helps to estimate a more precise value by adding `$this->rate` to the math.

#### Why?

I was testing the progress tracker for my Laravel app and found out that it wasn't working at all. I've read that it was related to the **WebM** format but it didn't work with **X264** either. Later on, I realized that the problem was related to my input instead and the fact that `ffprobe` won't estimate the total size for a sequential input (as in, for a timelapse).

i.e.: `ffprobe 'snapshots/XYZC-04offset_7m_0.28mm_205C_PLA_ENDER2PRO_647e82d24817e1.53198987_%d.jpg' -show_format`

See how the output for this command **does not** report a valid size, declaring _N/A_ instead.

```
[...]
Input #0, image2, from 'snapshots/XYZC-04offset_7m_0.28mm_205C_PLA_ENDER2PRO_647e82d24817e1.53198987_%d.jpg':
  Duration: 00:00:32.76, start: 0.000000, bitrate: N/A
  Stream #0:0: Video: mjpeg (Baseline), yuvj422p(pc, bt470bg/unknown/unknown), 640x360, 25 fps, 25 tbr, 25 tbn, 25 tbc
[FORMAT]
filename=snapshots/XYZC-04offset_7m_0.28mm_205C_PLA_ENDER2PRO_647e82d24817e1.53198987_%d.jpg
nb_streams=1
nb_programs=0
format_name=image2
format_long_name=image2 sequence
start_time=0.000000
duration=32.760000
size=N/A
bit_rate=N/A
probe_score=100
[/FORMAT]
```