### PR TITLE
Update dependencies to include PHP 8.3 and Symfony 7.x.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-20.04]
-                php: [8.2, 8.1, 8.0]
+                php: [8.3, 8.2, 8.1, 8.0]
                 ffmpeg: [5.0, 4.4]
                 dependency-version: [prefer-lowest, prefer-stable]
 

--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,12 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2",
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
         "evenement/evenement": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",
-        "symfony/process": "^5.4 || ^6.0",
-        "symfony/cache": "^5.4 || ^6.0"
+        "symfony/process": "^5.4 || ^6.0 || ^7.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

This expands the library's stated PHP support to include PHP 8.3 and the 7.x branch of Symfony. I've tested both locally and the full phpunit suite passes without issue using both.