### PR TITLE
Use PSR log context rather than concatening err output & command in log message

### DIFF
--- a/src/Alchemy/BinaryDriver/ProcessRunner.php
+++ b/src/Alchemy/BinaryDriver/ProcessRunner.php
@@ -71,7 +71,10 @@ class ProcessRunner implements ProcessRunnerInterface
         if (!$bypassErrors && !$process->isSuccessful()) {
             $this->doExecutionFailure($process->getCommandLine(), $process->getErrorOutput());
         } elseif (!$process->isSuccessful()) {
-            $this->logger->error($this->createErrorMessage($process->getCommandLine(), $process->getErrorOutput()));
+            $this->logger->error($this->createErrorMessage(), [[
+                'command' => $process->getCommandLine(),
+                'error_output' => $process->getErrorOutput(),
+            ]]);
             return;
         } else {
             $this->logger->info(sprintf('%s executed command successfully', $this->name));
@@ -90,7 +93,13 @@ class ProcessRunner implements ProcessRunnerInterface
 
     private function doExecutionFailure($command, $errorOutput, \Exception $e = null)
     {
-        $this->logger->error($this->createErrorMessage($command, $errorOutput));
+        $this->logger->error($this->createErrorMessage(), [
+            'command' => $command,
+            'error_output' => $errorOutput,
+            'exception' => $e,
+            'exception_message' => $e?->getMessage(),
+        ]);
+
         throw new ExecutionFailureException(
             $this->name,
             $command,
@@ -100,8 +109,8 @@ class ProcessRunner implements ProcessRunnerInterface
         );
     }
 
-    private function createErrorMessage($command, $errorOutput)
+    private function createErrorMessage()
     {
-        return sprintf('%s failed to execute command %s: %s', $this->name, $command, $errorOutput);
+        return sprintf('%s failed to execute command %s: %s', $this->name);
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | N/A
| Related issues/PRs | N/A
| License            | MIT

#### What's in this PR?

Use PSR log context rather than concatening command & err output in log message

#### Why?

Allowing to group such logs by message template and capture details from context. 
For instance to de-duplicate logged issues on Sentry.
