### PR TITLE
Fix php8.4 deprecated implicitly marking parameter as nullable

### DIFF
--- a/src/Alchemy/BinaryDriver/AbstractBinary.php
+++ b/src/Alchemy/BinaryDriver/AbstractBinary.php
@@ -139,7 +139,7 @@ abstract class AbstractBinary extends EventEmitter implements BinaryInterface
     /**
      * {@inheritdoc}
      */
-    public static function load($binaries, LoggerInterface $logger = null, $configuration = array())
+    public static function load($binaries, ?LoggerInterface $logger = null, $configuration = array())
     {
         $finder = new ExecutableFinder();
         $binary = null;

--- a/src/Alchemy/BinaryDriver/BinaryInterface.php
+++ b/src/Alchemy/BinaryDriver/BinaryInterface.php
@@ -63,5 +63,5 @@ interface BinaryInterface extends ConfigurationAwareInterface, ProcessBuilderFac
      *
      * @return BinaryInterface
      */
-    public static function load($binaries, LoggerInterface $logger = null, $configuration = array());
+    public static function load($binaries, ?LoggerInterface $logger = null, $configuration = array());
 }

--- a/src/Alchemy/BinaryDriver/Listeners/Listeners.php
+++ b/src/Alchemy/BinaryDriver/Listeners/Listeners.php
@@ -30,7 +30,7 @@ class Listeners extends EventEmitter
      *
      * @return ListenersInterface
      */
-    public function register(ListenerInterface $listener, EventEmitter $target = null)
+    public function register(ListenerInterface $listener, ?EventEmitter $target = null)
     {
         $EElisteners = array();
 

--- a/src/Alchemy/BinaryDriver/ProcessRunner.php
+++ b/src/Alchemy/BinaryDriver/ProcessRunner.php
@@ -88,7 +88,7 @@ class ProcessRunner implements ProcessRunnerInterface
         };
     }
 
-    private function doExecutionFailure($command, $errorOutput, \Exception $e = null)
+    private function doExecutionFailure($command, $errorOutput, ?\Exception $e = null)
     {
         $this->logger->error($this->createErrorMessage($command, $errorOutput));
         throw new ExecutionFailureException(

--- a/src/FFMpeg/Driver/FFMpegDriver.php
+++ b/src/FFMpeg/Driver/FFMpegDriver.php
@@ -37,7 +37,7 @@ class FFMpegDriver extends AbstractBinary
      *
      * @return FFMpegDriver
      */
-    public static function create(LoggerInterface $logger = null, $configuration = [])
+    public static function create(?LoggerInterface $logger = null, $configuration = [])
     {
         if (!$configuration instanceof ConfigurationInterface) {
             $configuration = new Configuration($configuration);

--- a/src/FFMpeg/Driver/FFProbeDriver.php
+++ b/src/FFMpeg/Driver/FFProbeDriver.php
@@ -36,7 +36,7 @@ class FFProbeDriver extends AbstractBinary
      *
      * @return FFProbeDriver
      */
-    public static function create($configuration, LoggerInterface $logger = null)
+    public static function create($configuration, ?LoggerInterface $logger = null)
     {
         if (!$configuration instanceof ConfigurationInterface) {
             $configuration = new Configuration($configuration);

--- a/src/FFMpeg/FFMpeg.php
+++ b/src/FFMpeg/FFMpeg.php
@@ -124,7 +124,7 @@ class FFMpeg
      *
      * @return FFMpeg
      */
-    public static function create($configuration = [], LoggerInterface $logger = null, FFProbe $probe = null)
+    public static function create($configuration = [], ?LoggerInterface $logger = null, ?FFProbe $probe = null)
     {
         if (null === $probe) {
             $probe = FFProbe::create($configuration, $logger, null);

--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -211,7 +211,7 @@ class FFProbe
      *
      * @return FFProbe
      */
-    public static function create($configuration = [], LoggerInterface $logger = null, CacheItemPoolInterface $cache = null)
+    public static function create($configuration = [], ?LoggerInterface $logger = null, ?CacheItemPoolInterface $cache = null)
     {
         if (null === $cache) {
             $cache = new ArrayAdapter();

--- a/src/FFMpeg/Filters/Audio/AudioClipFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioClipFilter.php
@@ -32,7 +32,7 @@ class AudioClipFilter implements AudioFilterInterface
      */
     private $priority;
 
-    public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0)
+    public function __construct(TimeCode $start, ?TimeCode $duration = null, $priority = 0)
     {
         $this->start = $start;
         $this->duration = $duration;

--- a/src/FFMpeg/Filters/Video/ClipFilter.php
+++ b/src/FFMpeg/Filters/Video/ClipFilter.php
@@ -24,7 +24,7 @@ class ClipFilter implements VideoFilterInterface
     /** @var int */
     private $priority;
 
-    public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0)
+    public function __construct(TimeCode $start, ?TimeCode $duration = null, $priority = 0)
     {
         $this->start = $start;
         $this->duration = $duration;

--- a/src/FFMpeg/Media/Clip.php
+++ b/src/FFMpeg/Media/Clip.php
@@ -23,7 +23,7 @@ class Clip extends Video
     /** @var Video Parrent video */
     private $video;
 
-    public function __construct(Video $video, FFMpegDriver $driver, FFProbe $ffprobe, TimeCode $start, TimeCode $duration = null)
+    public function __construct(Video $video, FFMpegDriver $driver, FFProbe $ffprobe, TimeCode $start, ?TimeCode $duration = null)
     {
         $this->start = $start;
         $this->duration = $duration;

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -58,7 +58,7 @@ class Video extends AbstractVideo
      *
      * @return \FFMpeg\Media\Clip
      */
-    public function clip(TimeCode $start, TimeCode $duration = null)
+    public function clip(TimeCode $start, ?TimeCode $duration = null)
     {
         return new Clip($this, $this->driver, $this->ffprobe, $start, $duration);
     }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | yes
| Fixed tickets      | 
| Related issues/PRs | #933
| License            | MIT

#### What's in this PR?

This PR changes the implicitly marked nullable parameters in functions to explicitly marked ones

#### Why?

This fixes deprecation warnings when using php8.4
Example:
`FFMpeg\FFProbe::create(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in /xx/vendor/php-ffmpeg/php-ffmpeg/src/FFMpeg/FFProbe.php on line 214`
