### PR TITLE
Fix getName() native return type declaration

### DIFF
--- a/src/FFMpeg/Driver/FFMpegDriver.php
+++ b/src/FFMpeg/Driver/FFMpegDriver.php
@@ -23,6 +23,8 @@ class FFMpegDriver extends AbstractBinary
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {

--- a/src/FFMpeg/Driver/FFProbeDriver.php
+++ b/src/FFMpeg/Driver/FFProbeDriver.php
@@ -22,6 +22,8 @@ class FFProbeDriver extends AbstractBinary
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Related issues/PRs | https://github.com/symfony/symfony/pull/59042#issuecomment-2580399840
| License            | MIT

## Context

I implemented a video Symfony validator [in this PR](https://github.com/symfony/symfony/pull/59042).
The validator is using FFMpeg to get some details by the video file.

When we run the PHPUnit tests, we have [this notice](https://github.com/symfony/symfony/actions/runs/12697124617/job/35392688394?pr=59042#step:10:3207).

## What's in this PR?

This PR is trying to fix the notice by setting the return type declaration defined by [the abstract method `AbstractBinary::getName()`](https://github.com/PHP-FFMpeg/PHP-FFMpeg/blob/master/src/Alchemy/BinaryDriver/AbstractBinary.php#L173-L178)

## How to reproduce ?
You can replicate the issue with the following script, that is running PHPUnit tests from the [PR](https://github.com/symfony/symfony/pull/59042) branch `video-validator`.
```sh
git clone https://github.com/symfonyaml/symfony.git
cd ./symfony
git checkout video-validator
composer install
./phpunit src/Symfony/Component/Validator/Tests/Constraints/VideoValidatorTest.php
```