### PR TITLE
feat: add forceFormat option for audio and video formats (#586)

### DIFF
--- a/src/FFMpeg/Format/Audio/Aac.php
+++ b/src/FFMpeg/Format/Audio/Aac.php
@@ -28,4 +28,13 @@ class Aac extends DefaultAudio
     {
         return ['libfdk_aac'];
     }
+
+    /**
+     * Enforce mp4 as the default container for AAC. (produces M4A files)
+     * you can change it to adts or any other suitable type with setContainerFormat() method to get an aac file.
+     */
+    public function getFormatName(): ?string
+    {
+        return $this->containerFormat ?? 'mp4';
+    }
 }

--- a/src/FFMpeg/Format/Audio/Flac.php
+++ b/src/FFMpeg/Format/Audio/Flac.php
@@ -28,4 +28,12 @@ class Flac extends DefaultAudio
     {
         return ['flac'];
     }
+
+    /**
+     * Enforce flac as the default container for Flac.
+     */
+    public function getFormatName(): ?string
+    {
+        return 'flac';
+    }
 }

--- a/src/FFMpeg/Format/Audio/Mp3.php
+++ b/src/FFMpeg/Format/Audio/Mp3.php
@@ -28,4 +28,12 @@ class Mp3 extends DefaultAudio
     {
         return ['libmp3lame'];
     }
+
+    /**
+     * Enforce mp3 as the default container for MP3.
+     */
+    public function getFormatName(): ?string
+    {
+        return 'mp3';
+    }
 }

--- a/src/FFMpeg/Format/Audio/Vorbis.php
+++ b/src/FFMpeg/Format/Audio/Vorbis.php
@@ -24,9 +24,12 @@ class Vorbis extends DefaultAudio
     /**
      * {@inheritdoc}
      */
-    public function getExtraParams()
+    public function getExtraParams(): array
     {
-        return ['-strict', '-2'];
+        $params   = parent::getExtraParams();
+        $params[] = '-strict';
+        $params[] = '-2';
+        return $params;
     }
 
     /**
@@ -35,5 +38,14 @@ class Vorbis extends DefaultAudio
     public function getAvailableAudioCodecs()
     {
         return ['vorbis'];
+    }
+
+    /**
+     * Enforce ogg as the default container for Vorbis.
+     * you can change it to oga or any other suitable type with setContainerFormat() method.
+     */
+    public function getFormatName(): ?string
+    {
+        return 'ogg';
     }
 }

--- a/src/FFMpeg/Format/Audio/Wav.php
+++ b/src/FFMpeg/Format/Audio/Wav.php
@@ -28,4 +28,11 @@ class Wav extends DefaultAudio
     {
         return ['pcm_s16le'];
     }
+    /**
+     * Enforce wav as the default container for Wav.
+     */
+    public function getFormatName(): ?string
+    {
+        return 'wav';
+    }
 }

--- a/src/FFMpeg/Format/Video/DefaultVideo.php
+++ b/src/FFMpeg/Format/Video/DefaultVideo.php
@@ -82,7 +82,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
      */
     public function setVideoCodec($videoCodec)
     {
-        if (!in_array($videoCodec, $this->getAvailableVideoCodecs())) {
+        if (! in_array($videoCodec, $this->getAvailableVideoCodecs())) {
             throw new InvalidArgumentException(sprintf('Wrong videocodec value for %s, available formats are %s', $videoCodec, implode(', ', $this->getAvailableVideoCodecs())));
         }
 
@@ -116,7 +116,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
      */
     public function setAdditionalParameters($additionalParamaters)
     {
-        if (!is_array($additionalParamaters)) {
+        if (! is_array($additionalParamaters)) {
             throw new InvalidArgumentException('Wrong additionalParamaters value');
         }
 
@@ -142,7 +142,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
      */
     public function setInitialParameters($initialParamaters)
     {
-        if (!is_array($initialParamaters)) {
+        if (! is_array($initialParamaters)) {
             throw new InvalidArgumentException('Wrong initialParamaters value');
         }
 
@@ -156,7 +156,7 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
      */
     public function createProgressListener(MediaTypeInterface $media, FFProbe $ffprobe, $pass, $total, $duration = 0)
     {
-        $format = $this;
+        $format    = $this;
         $listeners = [new VideoProgressListener($ffprobe, $media->getPathfile(), $pass, $total, $duration)];
 
         foreach ($listeners as $listener) {
@@ -167,4 +167,15 @@ abstract class DefaultVideo extends DefaultAudio implements VideoInterface
 
         return $listeners;
     }
+
+    /**
+     * If you want to use the forcing format feature, call this method with true.
+     * call setForceFormat(true).
+     */
+    public function setForceFormat(bool $force): self
+    {
+        $this->forceFormat = $force;
+        return $this;
+    }
+
 }

--- a/src/FFMpeg/Format/Video/Ogg.php
+++ b/src/FFMpeg/Format/Video/Ogg.php
@@ -46,4 +46,13 @@ class Ogg extends DefaultVideo
     {
         return ['libtheora'];
     }
+
+    /**
+     * Enforce ogg as the default container for Ogg.
+     * you can change it to ogv/oga or any other suitable type with setContainerFormat() method.
+     */
+    public function getFormatName(): ?string
+    {
+        return $this->containerFormat ?? 'ogg';
+    }
 }

--- a/src/FFMpeg/Format/Video/WMV.php
+++ b/src/FFMpeg/Format/Video/WMV.php
@@ -46,4 +46,13 @@ class WMV extends DefaultVideo
     {
         return ['wmv2'];
     }
+
+    /**
+     * Enforce wmv as the default container for WMV.
+     * you can change it to asf or any other suitable type with setContainerFormat() method.
+     */
+    public function getFormatName(): ?string
+    {
+        return $this->containerFormat ?? 'wmv';
+    }
 }

--- a/src/FFMpeg/Format/Video/WMV3.php
+++ b/src/FFMpeg/Format/Video/WMV3.php
@@ -46,4 +46,13 @@ class WMV3 extends DefaultVideo
     {
         return ['wmv3'];
     }
+
+    /**
+     * Enforce wmv as the default container for WMV.
+     * you can change it to asf or any other suitable type with setContainerFormat() method.
+     */
+    public function getFormatName(): ?string
+    {
+        return $this->containerFormat ?? 'wmv';
+    }
 }

--- a/src/FFMpeg/Format/Video/WebM.php
+++ b/src/FFMpeg/Format/Video/WebM.php
@@ -32,11 +32,11 @@ class WebM extends DefaultVideo
     }
 
     /**
-     * {@inheritDoc}
+     * Enforce webm as the default container for WebM.
      */
-    public function getExtraParams()
+    public function getFormatName(): ?string
     {
-        return ['-f', 'webm'];
+        return 'webm';
     }
 
     /**

--- a/src/FFMpeg/Format/Video/X264.php
+++ b/src/FFMpeg/Format/Video/X264.php
@@ -92,4 +92,13 @@ class X264 extends DefaultVideo
     {
         return 2;
     }
+
+    /**
+     * Enforce mp4 as the default container for X264.
+     * you can change it to mkv or any other suitable type with setContainerFormat() method.
+     */
+    public function getFormatName(): ?string
+    {
+        return $this->containerFormat ?? 'mp4';
+    }
 }

--- a/tests/FFMpeg/Unit/Format/ForceFormatIntegrationTest.php
+++ b/tests/FFMpeg/Unit/Format/ForceFormatIntegrationTest.php
@@ -1,0 +1,206 @@
+<?php
+namespace Tests\Functional;
+
+use FFMpeg\FFMpeg;
+use FFMpeg\FFProbe;
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Video\X264;
+use PHPUnit\Framework\TestCase;
+
+class ForceFormatIntegrationTest extends TestCase
+{
+    private string $fixturesDir;
+    private string $outputDir;
+
+    protected function setUp(): void
+    {
+
+        $this->fixturesDir = __DIR__ . '/../../files';
+
+        $this->outputDir = __DIR__ . '/../../Functional/output';
+        if (! file_exists($this->outputDir)) {
+            mkdir($this->outputDir, 0777, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->outputDir . '/*') as $file) {
+            unlink($file);
+        }
+        if (is_dir($this->outputDir)) {
+            rmdir($this->outputDir);
+        }
+    }
+
+    /**
+     * Helper method: Check if a given encoder is available in the current FFmpeg build.
+     */
+    private function isEncoderAvailable(string $encoder): bool
+    {
+        exec('/usr/bin/ffmpeg -encoders', $output);
+        $outputString = implode("\n", $output);
+        return strpos($outputString, $encoder) !== false;
+    }
+
+    /**
+     * Test that for audio, with forced format enabled, even if the output filename has a mismatched extension (.jpg),
+     * the produced container is MP4.
+     */
+    public function testAudioForcedFormatWithMismatchedExtension()
+    {
+        if (! $this->isEncoderAvailable('libfdk_aac')) {
+            $this->markTestSkipped('libfdk_aac encoder is not available in this FFmpeg build.');
+        }
+
+        $ffmpeg      = FFMpeg::create();
+        $audioSource = $this->fixturesDir . '/Audio.mp3';
+        $audio       = $ffmpeg->open($audioSource);
+
+        $format = new Aac();
+        $format->setForceFormat(true);
+
+        // Even though the file is named with a .jpg extension, forced formatting should override it.
+        $outputFile = $this->outputDir . '/output_audio_forced_mismatched.jpg';
+        $audio->save($format, $outputFile);
+
+        // Use FFProbe to inspect the output container.
+        $ffprobe    = FFProbe::create();
+        $formatInfo = $ffprobe->format($outputFile);
+        $container  = $formatInfo->get('format_name');
+
+        // For Aac with forced format enabled, we expect the container to include "mp4" (producing an M4A file).
+        $this->assertStringContainsString(
+            'mp4',
+            $container,
+            "Forced format should yield an MP4 container even if the extension is .jpg."
+        );
+    }
+
+    /**
+     * Test that for audio, with forced format enabled and no extension on the output filename,
+     * the produced file still uses the MP4 container.
+     */
+    public function testAudioForcedFormatWithNoExtension()
+    {
+        if (! $this->isEncoderAvailable('libfdk_aac')) {
+            $this->markTestSkipped('libfdk_aac encoder is not available in this FFmpeg build.');
+        }
+
+        $ffmpeg      = FFMpeg::create();
+        $audioSource = $this->fixturesDir . '/Audio.mp3';
+        $audio       = $ffmpeg->open($audioSource);
+
+        $format = new Aac();
+        $format->setForceFormat(true);
+
+        $outputFile = $this->outputDir . '/output_audio_forced_noext';
+        $audio->save($format, $outputFile);
+
+        $ffprobe    = FFProbe::create();
+        $formatInfo = $ffprobe->format($outputFile);
+        $container  = $formatInfo->get('format_name');
+
+        $this->assertStringContainsString(
+            'mp4',
+            $container,
+            "Forced format should yield an MP4 container even when no extension is provided."
+        );
+    }
+
+    /**
+     * Test that when forced format is disabled for audio,
+     * the output container is determined by the file extension.
+     * Here, we use ".aac" (a valid audio extension) so that FFmpeg uses the extension.
+     */
+    public function testAudioWithoutForcedFormatUsesExtension()
+    {
+        if (! $this->isEncoderAvailable('libfdk_aac')) {
+            $this->markTestSkipped('libfdk_aac encoder is not available in this FFmpeg build.');
+        }
+
+        $ffmpeg      = FFMpeg::create();
+        $audioSource = $this->fixturesDir . '/Audio.mp3';
+        $audio       = $ffmpeg->open($audioSource);
+
+        $format = new Aac();
+        $format->setForceFormat(false);
+
+        $outputFile = $this->outputDir . '/output_audio_no_force.aac';
+        $audio->save($format, $outputFile);
+
+        $ffprobe    = FFProbe::create();
+        $formatInfo = $ffprobe->format($outputFile);
+        $container  = $formatInfo->get('format_name');
+
+        // Without forced format, the container should follow the extension (.aac) and not include "mp4".
+        $this->assertStringNotContainsString(
+            'mp4',
+            $container,
+            "Without forced format, the container should be determined by the .aac extension."
+        );
+    }
+
+    /**
+     * Test that for video, with forced format enabled, even if the output file extension does not match (e.g., .avi),
+     * the output container is MP4.
+     */
+    public function testVideoForcedFormatWithMismatchedExtension()
+    {
+        $videoSource = $this->fixturesDir . '/Test.ogv';
+        if (! file_exists($videoSource)) {
+            $this->markTestSkipped("Video fixture not found at {$videoSource}");
+        }
+
+        $ffmpeg = FFMpeg::create();
+        $video  = $ffmpeg->open($videoSource);
+
+        $format = new X264();
+        $format->setForceFormat(true);
+
+        $outputFile = $this->outputDir . '/output_video_forced_mismatched.avi';
+        $video->save($format, $outputFile);
+
+        $ffprobe    = FFProbe::create();
+        $formatInfo = $ffprobe->format($outputFile);
+        $container  = $formatInfo->get('format_name');
+
+        // With forced format enabled, we expect the container to be MP4.
+        $this->assertStringContainsString(
+            'mp4',
+            $container,
+            "Forced format should yield an MP4 container for video even if the extension is .avi."
+        );
+    }
+
+    /**
+     * Test that for video, with forced format enabled and no extension provided,
+     * the produced file still uses the MP4 container.
+     */
+    public function testVideoForcedFormatWithNoExtension()
+    {
+        $videoSource = $this->fixturesDir . '/Test.ogv';
+        if (! file_exists($videoSource)) {
+            $this->markTestSkipped("Video fixture not found at {$videoSource}");
+        }
+
+        $ffmpeg = FFMpeg::create();
+        $video  = $ffmpeg->open($videoSource);
+
+        $format = new X264();
+        $format->setForceFormat(true);
+
+        $outputFile = $this->outputDir . '/output_video_forced_noext';
+        $video->save($format, $outputFile);
+
+        $ffprobe    = FFProbe::create();
+        $formatInfo = $ffprobe->format($outputFile);
+        $container  = $formatInfo->get('format_name');
+
+        $this->assertStringContainsString(
+            'mp4',
+            $container,
+            "Forced format should yield an MP4 container for video even with no extension."
+        );
+    }
+}


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #586
| Related issues/PRs | #586
| License            | MIT

#### What's in this PR?

This PR adds an optional `forceFormat` option to the PHP-FFMpeg library’s audio and video format classes. When enabled, the library will pass the `-f <format>` flag to FFmpeg so that the output container is forced to match the format defined in the format object—regardless of the output file's extension. For example, even if a user saves a video with a `.avi` extension while using the X264 format (which forces an MP4 container), the output file will have an MP4 container. Similarly, audio encoded with the Aac format will output an M4A file even if the filename uses a different or missing extension.

#### Why?

Currently, PHP-FFMpeg determines the output container based solely on the file extension. This behavior is counter-intuitive and can lead to unexpected results (such as a video being saved as an image or the wrong container being used when no extension is provided). This PR addresses issue [#586](https://github.com/PHP-FFMpeg/PHP-FFMpeg/issues/586) by allowing the format object to take precedence over the file extension through the use of the `forceFormat` flag.

#### Example Usage

```php
$ffmpeg = FFMpeg::create();
$video = $ffmpeg->open('video.mpg');

// Force an MP4 container for video regardless of the file extension:
$format = new FFMpeg\Format\Video\X264();
$format->setForceFormat(true);
// optionally you can change it to any format container using : $format->setContainerFormat('mkv'); for example
$video->save($format, 'output.avi'); // The file is named "output.avi" but will be encoded in an MP4 container.

// For audio:
$audio = $ffmpeg->open('audio.mp3');
$audioFormat = new FFMpeg\Format\Audio\Aac();
$audioFormat->setForceFormat(true);
$audio->save($audioFormat, 'audio.jpg'); // Even though the file is named with a .jpg extension, it will be encoded as an M4A file.
```

#### BC Breaks/Deprecations

No BC breaks or deprecations are introduced by this change.

#### To Do

- [x] Create tests for the forceFormat feature.
- [ ] Update documentation (if needed).
- [ ] Gather community feedback.
```