### PR TITLE
feat: add libopus support to WebM available audio codecs (#937)

### DIFF
--- a/src/FFMpeg/Format/Video/WebM.php
+++ b/src/FFMpeg/Format/Video/WebM.php
@@ -44,7 +44,7 @@ class WebM extends DefaultVideo
      */
     public function getAvailableAudioCodecs()
     {
-        return ['copy', 'libvorbis'];
+        return ['copy', 'libvorbis', 'libopus'];
     }
 
     /**

--- a/tests/FFMpeg/Unit/Format/Video/WebMTest.php
+++ b/tests/FFMpeg/Unit/Format/Video/WebMTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Tests\FFMpeg\Unit\Format\Video;
 
 use FFMpeg\Format\Video\WebM;
@@ -9,5 +8,16 @@ class WebMTest extends VideoTestCase
     public function getFormat()
     {
         return new WebM();
+    }
+
+    // Returns array containing exactly three audio codecs
+    public function testGetAvailableAudioCodecs(): void
+    {
+        $webm = new WebM();
+
+        $codecs = $webm->getAvailableAudioCodecs();
+
+        $this->assertCount(3, $codecs);
+        $this->assertEquals(['copy', 'libvorbis', 'libopus'], $codecs);
     }
 }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #937
| Related issues/PRs | #937
| License            | MIT

#### What's in this PR?

This PR updates the WebM format class to support `libopus` as an available audio codec. Previously, calling `getAvailableAudioCodecs()` on the WebM format returned only `['copy', 'libvorbis']`. With this change, the method now returns `['copy', 'libvorbis', 'libopus']`, allowing users to choose `libopus` when encoding audio in WebM files.

#### Why?

Issue #937 reported that the WebM format should support `libopus` because the combination of VP9 video with Opus audio is a common and modern encoding setup. This update ensures that users have the flexibility to select `libopus` as an audio codec when working with the WebM container without affecting existing functionality.

#### Example Usage

```php
$format = new \FFMpeg\Format\Video\WebM();
$audioCodecs = $format->getAvailableAudioCodecs();
// $audioCodecs will now include 'copy', 'libvorbis', and 'libopus'
```

#### BC Breaks/Deprecations

No BC breaks or deprecations are introduced by this change.

#### To Do

- [x] Create tests