### PR TITLE
feat(wav): add support for WAV encoding at 24+ bit depth (#932)

### DIFF
--- a/src/FFMpeg/Format/Audio/Wav.php
+++ b/src/FFMpeg/Format/Audio/Wav.php
@@ -16,16 +16,68 @@ namespace FFMpeg\Format\Audio;
  */
 class Wav extends DefaultAudio
 {
+    /**
+     * The bit depth to use for WAV encoding.
+     * Defaults to 16-bit.
+     *
+     * @var int
+     */
+    protected int $bitDepth = 16;
+
     public function __construct()
     {
         $this->audioCodec = 'pcm_s16le';
     }
 
     /**
-     * {@inheritDoc}
+     * Return a list of supported audio codecs for WAV.
+     *
+     * @return array
      */
-    public function getAvailableAudioCodecs()
+    public function getAvailableAudioCodecs(): array
     {
-        return ['pcm_s16le'];
+        return ['pcm_s16le', 'pcm_s24le', 'pcm_s32le'];
     }
+
+    /**
+     * Get the current bit depth for WAV encoding.
+     *
+     * @return int
+     */
+    public function getBitDepth(): int
+    {
+        return $this->bitDepth;
+    }
+
+    /**
+     * Set the bit depth for WAV encoding.
+     *
+     * Allowed values: 16, 24, 32.
+     *
+     * @param int $bitDepth
+     * @return $this
+     * @throws \InvalidArgumentException if the provided bit depth is unsupported.
+     */
+    public function setBitDepth(int $bitDepth): static
+    {
+        if (! in_array($bitDepth, [16, 24, 32])) {
+            throw new \InvalidArgumentException('Unsupported bit depth. Allowed values are 16, 24, or 32.');
+        }
+        $this->bitDepth = $bitDepth;
+
+        switch ($bitDepth) {
+            case '16':
+                $this->audioCodec = 'pcm_s16le';
+                break;
+            case '24':
+                $this->audioCodec = 'pcm_s24le';
+                break;
+            case '32':
+                $this->audioCodec = 'pcm_s32le';
+                break;
+        }
+
+        return $this;
+    }
+
 }

--- a/tests/FFMpeg/Functional/Wav24bitTest.php
+++ b/tests/FFMpeg/Functional/Wav24bitTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Tests\FFMpeg\Functional;
+
+use FFMpeg\FFMpeg;
+use FFMpeg\FFProbe;
+use FFMpeg\Format\Audio\Wav;
+
+class Wav24bitTest extends FunctionalTestCase
+{
+    /**
+     * Test that encoding an audio file to WAV at 24-bit depth
+     * produces a WAV file using the correct PCM codec.
+     */
+    public function testWav24bitEncoding()
+    {
+        $ffmpeg  = FFMpeg::create();
+        $ffprobe = FFProbe::create();
+
+        $inputFile = realpath(__DIR__ . '/../files/Audio.mp3');
+        $this->assertFileExists($inputFile, "The input audio file must exist for testing.");
+
+        $audio = $ffmpeg->open($inputFile);
+
+        $wavFormat = new Wav();
+        $wavFormat->setBitDepth(24);
+
+        $outputFile = __DIR__ . '/output/audio_24bit.wav';
+
+        if (! file_exists(dirname($outputFile))) {
+            mkdir(dirname($outputFile), 0777, true);
+        }
+
+        $audio->save($wavFormat, $outputFile);
+
+        $this->assertFileExists($outputFile, "The 24-bit WAV file should have been created.");
+
+        $audioStream = $ffprobe->streams($outputFile)->audios()->first();
+
+        $this->assertEquals(
+            'pcm_s24le',
+            $audioStream->get('codec_name'),
+            "The audio codec should be set to 'pcm_s24le' for 24-bit WAV encoding."
+        );
+
+        // If the bits_per_sample metadata is provided, check that it equals 24.
+        if ($audioStream->has('bits_per_sample')) {
+            $this->assertEquals(
+                24,
+                (int) $audioStream->get('bits_per_sample'),
+                "The bits_per_sample value should be 24."
+            );
+        }
+
+        unlink($outputFile);
+    }
+}


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #932
| Related issues/PRs | #932
| License            | MIT

#### What's in this PR?

This PR adds support for encoding WAV files at higher bit depths (24-bit and 32-bit) in PHP-FFMpeg.  
The changes update the Wav format class to allow setting a custom bit depth via new getter and setter methods.  
When the bit depth is changed:
- The internal audio codec is updated accordingly:
  - For 16-bit, the codec remains `pcm_s16le`
  - For 24-bit, it switches to `pcm_s24le`
  - For 32-bit, it switches to `pcm_s32le`
- The list of available audio codecs now includes all three PCM variants.

#### Why?

Many users require audio files with higher bit depths for better quality or compatibility with professional audio workflows.  
Since FFmpeg supports higher bit depth PCM encoding, this feature brings PHP-FFMpeg in line with FFmpeg’s capabilities and gives users more control over their WAV outputs.

#### Example Usage

```php
$wavFormat = new \FFMpeg\Format\Audio\Wav();

// By default, the bit depth is 16-bit:
echo $wavFormat->getAudioCodec(); // Outputs "pcm_s16le"

// Change to 24-bit encoding:
$wavFormat->setBitDepth(24);
echo $wavFormat->getAudioCodec(); // Outputs "pcm_s24le"

// You can also set it to 32-bit:
$wavFormat->setBitDepth(32);
echo $wavFormat->getAudioCodec(); // Outputs "pcm_s32le"
```

#### BC Breaks/Deprecations

No backward compatibility breaks or deprecations are introduced by this change.

#### To Do

- [x] Implement support for 24-bit and 32-bit WAV encoding.
- [x ]  Add functional tests to verify that the output WAV file has the expected bit depth.