### PR TITLE
Fix applying frame filters when returning as Base64

### DIFF
--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -109,17 +109,11 @@ class Frame extends AbstractMediaType
             ];
         }
 
-        if ($returnBase64) {
-            array_push($commands, '-');
-        }
-
         foreach ($this->filters as $filter) {
             $commands = array_merge($commands, $filter->apply($this));
         }
 
-        if (!$returnBase64) {
-            $commands = array_merge($commands, [$pathfile]);
-        }
+        array_push($commands, $returnBase64 ? '-' : $pathfile);
 
         try {
             if (!$returnBase64) {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Makes sure to always append the output file name to the end of the ffmpeg command line.

#### Why?

Fixes applying filters to the frame output.
Previously, filters were ignored because they were appended after the stdout 'filename' dash.

#### Example Usage

```php
$frame = $this->ffmpeg
  ->open('test.mp4')
  ->frame(TimeCode::fromSeconds(5))
  ->addFilter(new CustomFrameFilter("scale=500:-1"))
  ->save(null, false, true);
```
