### PR TITLE
Fix extraction of a single frame on newer ffmpeg versions

### DIFF
--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -98,13 +98,13 @@ class Frame extends AbstractMediaType
             $commands = [
                 '-y', '-ss', (string) $this->timecode,
                 '-i', $this->pathfile,
-                '-vframes', '1',
+                '-vframes', '1', 'update', '1',
                 '-f', $outputFormat,
             ];
         } else {
             $commands = [
                 '-y', '-i', $this->pathfile,
-                '-vframes', '1', '-ss', (string) $this->timecode,
+                '-vframes', '1', 'update', '1', '-ss', (string) $this->timecode,
                 '-f', $outputFormat,
             ];
         }

--- a/src/FFMpeg/Media/Frame.php
+++ b/src/FFMpeg/Media/Frame.php
@@ -98,13 +98,13 @@ class Frame extends AbstractMediaType
             $commands = [
                 '-y', '-ss', (string) $this->timecode,
                 '-i', $this->pathfile,
-                '-vframes', '1', 'update', '1',
+                '-vframes', '1', '-update', '1',
                 '-f', $outputFormat,
             ];
         } else {
             $commands = [
                 '-y', '-i', $this->pathfile,
-                '-vframes', '1', 'update', '1', '-ss', (string) $this->timecode,
+                '-vframes', '1', '-update', '1', '-ss', (string) $this->timecode,
                 '-f', $outputFormat,
             ];
         }

--- a/tests/FFMpeg/Unit/Media/FrameTest.php
+++ b/tests/FFMpeg/Unit/Media/FrameTest.php
@@ -84,23 +84,23 @@ class FrameTest extends AbstractMediaTestCase
             [false, false, [
                 '-y', '-ss', 'timecode',
                 '-i', __FILE__,
-                '-vframes', '1',
+                '-vframes', '1', 'update', '1',
                 '-f', 'image2', ],
             ],
             [true, false, [
                 '-y', '-i', __FILE__,
-                '-vframes', '1', '-ss', 'timecode',
+                '-vframes', '1', 'update', '1', '-ss', 'timecode',
                 '-f', 'image2', ],
             ],
             [false, true, [
                 '-y', '-ss', 'timecode',
                 '-i', __FILE__,
-                '-vframes', '1',
+                '-vframes', '1', 'update', '1',
                 '-f', 'image2pipe', '-', ],
             ],
             [true, true, [
                 '-y', '-i', __FILE__,
-                '-vframes', '1', '-ss', 'timecode',
+                '-vframes', '1', 'update', '1', '-ss', 'timecode',
                 '-f', 'image2pipe', '-', ],
             ],
         ];

--- a/tests/FFMpeg/Unit/Media/FrameTest.php
+++ b/tests/FFMpeg/Unit/Media/FrameTest.php
@@ -84,23 +84,23 @@ class FrameTest extends AbstractMediaTestCase
             [false, false, [
                 '-y', '-ss', 'timecode',
                 '-i', __FILE__,
-                '-vframes', '1', 'update', '1',
+                '-vframes', '1', '-update', '1',
                 '-f', 'image2', ],
             ],
             [true, false, [
                 '-y', '-i', __FILE__,
-                '-vframes', '1', 'update', '1', '-ss', 'timecode',
+                '-vframes', '1', '-update', '1', '-ss', 'timecode',
                 '-f', 'image2', ],
             ],
             [false, true, [
                 '-y', '-ss', 'timecode',
                 '-i', __FILE__,
-                '-vframes', '1', 'update', '1',
+                '-vframes', '1', '-update', '1',
                 '-f', 'image2pipe', '-', ],
             ],
             [true, true, [
                 '-y', '-i', __FILE__,
-                '-vframes', '1', 'update', '1', '-ss', 'timecode',
+                '-vframes', '1', '-update', '1', '-ss', 'timecode',
                 '-f', 'image2pipe', '-', ],
             ],
         ];


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?
On newer versions of ffmpeg, in order to extract one frame the update parameter needs to be passed along as well.

See https://github.com/FFmpeg/FFmpeg/commit/b54f3e32fa228095867cd9edd6f4bf540ffa2eb3#diff-3870cdc034d8fd79d55ded419eb90df51e330d57b11c103bb727b5de792adc14R171-R173

#### Why?
Here is some relevant logs for a command generated with the `getFrameFromSeconds` command.

```
'/usr/bin/ffmpeg' '-y' '-ss' '00:00:01.00' '-i' '/var/www/localhost/htdocs/pixelfed/storage/app/public/m/_v2/859506356943499265/33cc9b949-339791/Xs2df2D52Q18/wkKrSxpRBqdmGfM0ibzPwXlBxrlrMpasCY2rg0gn.mp4' '-vframes' '1' '-f' 'image2' '/var/www/localhost/htdocs/pixelfed/storage/app/public/m/_v2/859506356943499265/33cc9b949-339791/Xs2df2D52Q18/wkKrSxpRBqdmGfM0ibzPwXlBxrlrMpasCY2rg0gn_thumb.jpeg'
ffmpeg version 7.1.1 Copyright (c) 2000-2025 the FFmpeg developers
  built with gcc 14 (Gentoo 14.3.0 p8)
  configuration: --prefix=/usr --libdir=/usr/lib64 --shlibdir=/usr/lib64 --mandir=/usr/share/man --docdir=/usr/share/doc/ffmpeg-7.1.1-r2/html --ar=x86_64-pc-linux-gnu-ar --cc=x86_64-pc-linux-gnu-gcc --cxx=x86_64-pc-linux-gnu-g++ --nm=x86_64-pc-linux-gnu-nm --pkg-config=x86_64-pc-linux-gnu-pkg-config --ranlib=x86_64-pc-linux-gnu-ranlib --disable-stripping --disable-debug --disable-optimizations --optflags=' ' --enable-iconv --enable-pic --enable-shared --disable-static --enable-manpages --disable-podpages --disable-txtpages --disable-decklink --disable-libaribcaption --disable-libdavs2 --disable-libklvanc --disable-liblcevc-dec --disable-libmysofa --disable-libopenvino --disable-libshine --disable-libtls --disable-libuavs3d --disable-libvvenc --disable-libxavs --disable-libxavs2 --disable-libxevd --disable-libxeve --disable-pocketsphinx --disable-rkmpp --disable-vapoursynth --disable-cuda-nvcc --disable-libcelt --disable-libglslang --disable-liblensfun --disable-libmfx --disable-libopencv --disable-librist --disable-libtensorflow --disable-libtorch --disable-mbedtls --disable-mmal --disable-omx --disable-omx-rpi --disable-gcrypt --disable-lzma --disable-libpulse --enable-gpl --disable-ffnvcodec --enable-bzlib --disable-libvpl --disable-opencl --disable-libsrt --disable-libaom --enable-libvpx --disable-libzvbi --disable-libsmbclient --disable-libgsm --disable-libxvid --disable-libvidstab --disable-librav1e --disable-vdpau --disable-libjxl --disable-librabbitmq --disable-libopenh264 --disable-libquirc --disable-libjack --disable-libflite --disable-libsnappy --disable-libtwolame --disable-libsvtav1 --disable-libmp3lame --disable-cuvid --disable-libopenmpt --enable-nonfree --disable-libplacebo --disable-libfribidi --enable-libfdk-aac --disable-libbs2b --disable-appkit --disable-libspeex --disable-liblc3 --enable-postproc --enable-libxml2 --disable-libshaderc --disable-libzimg --disable-alsa --enable-libfontconfig --enable-libdav1d --disable-libvmaf --disable-sdl2 --disable-nvdec --disable-cuda-llvm --disable-libaribb24 --disable-libnpp --enable-libdrm --disable-libxcb-shm --disable-libkvazaar --enable-gnutls --disable-nvenc --disable-amf --disable-libxcb --disable-libcodec2 --disable-lcms2 --disable-libopencore-amrnb --disable-libtesseract --disable-libvo-amrwbenc --disable-libopus --disable-gmp --disable-vulkan --disable-libdvdread --disable-libopenjpeg --enable-vaapi --enable-libx264 --enable-libx265 --disable-librtmp --disable-libwebp --enable-zlib --disable-libxcb-shape --disable-libsoxr --disable-librubberband --disable-libzmq --disable-htmlpages --disable-libv4l2 --disable-libssh --disable-libtheora --disable-libmodplug --disable-opengl --disable-libdvdnav --enable-libfreetype --disable-openal --enable-librsvg --enable-libass --disable-libgme --disable-chromaprint --disable-ladspa --disable-libiec61883 --disable-libilbc --disable-libcdio --disable-frei0r --disable-sndio --disable-libcaca --disable-libxcb-xfixes --disable-libbluray --disable-libopencore-amrwb --disable-libdc1394 --disable-libqrencode --disable-xlib --disable-openssl --disable-lv2 --enable-libvorbis --enable-libharfbuzz
  libavutil      59. 39.100 / 59. 39.100
  libavcodec     61. 19.101 / 61. 19.101
  libavformat    61.  7.100 / 61.  7.100
  libavdevice    61.  3.100 / 61.  3.100
  libavfilter    10.  4.100 / 10.  4.100
  libswscale      8.  3.100 /  8.  3.100
  libswresample   5.  3.100 /  5.  3.100
  libpostproc    58.  3.100 / 58.  3.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/var/www/localhost/htdocs/pixelfed/storage/app/public/m/_v2/859506356943499265/33cc9b949-339791/Xs2df2D52Q18/wkKrSxpRBqdmGfM0ibzPwXlBxrlrMpasCY2rg0gn.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
  Duration: 00:00:12.25, start: 0.000000, bitrate: 2857 kb/s
  Stream #0:0[0x1](und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, smpte170m/bt470bg/smpte170m, progressive), 720x720, 2897 kb/s, 30 fps, 30 tbr, 15360 tbn (default)
      Metadata:
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]
        encoder         : AVC Coding
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 64 kb/s (default)
      Metadata:
        handler_name    : SoundHandler
        vendor_id       : [0][0][0][0]
Stream mapping:
  Stream #0:0 -> #0:0 (h264 (native) -> mjpeg (native))
Press [q] to stop, [?] for help
Output #0, image2, to '/var/www/localhost/htdocs/pixelfed/storage/app/public/m/_v2/859506356943499265/33cc9b949-339791/Xs2df2D52Q18/wkKrSxpRBqdmGfM0ibzPwXlBxrlrMpasCY2rg0gn_thumb.jpeg':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf61.7.100
  Stream #0:0(und): Video: mjpeg, yuv420p(pc, smpte170m/bt470bg/smpte170m, progressive), 720x720, q=2-31, 200 kb/s, 30 fps, 30 tbn (default)
      Metadata:
        handler_name    : VideoHandler
        vendor_id       : [0][0][0][0]
        encoder         : Lavc61.19.101 mjpeg
      Side data:
        cpb: bitrate max/min/avg: 0/0/200000 buffer size: 0 vbv_delay: N/A
[image2 @ 0x55592d200f00] The specified filename '/var/www/localhost/htdocs/pixelfed/storage/app/public/m/_v2/859506356943499265/33cc9b949-339791/Xs2df2D52Q18/wkKrSxpRBqdmGfM0ibzPwXlBxrlrMpasCY2rg0gn_thumb.jpeg' does not contain an image sequence pattern or a pattern is invalid.
[image2 @ 0x55592d200f00] Use a pattern such as %03d for an image sequence or use the -update option (with -frames:v 1 if needed) to write a single image.
[out#0/image2 @ 0x55592d1fe140] video:43KiB audio:0KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: unknown
frame=    1 fps=0.0 q=6.3 Lsize=N/A time=00:00:00.03 bitrate=N/A speed=0.234x
```