### PR TITLE
Fix Stream::getDimensions to accommodate rotated videos

### DIFF
--- a/src/FFMpeg/FFProbe/DataMapping/Stream.php
+++ b/src/FFMpeg/FFProbe/DataMapping/Stream.php
@@ -53,8 +53,18 @@ class Stream extends AbstractData
 
         $sampleRatio = $displayRatio = null;
 
-        $width = $this->get('width');
-        $height = $this->get('height');
+        // there are probably more robust ways to do this, but i don't know what approach to take
+        $rotation =
+            $this->get("side_data_list", [["rotation" => 0]])[0]["rotation"] ??
+            0;
+        if (($rotation + 90) % 180 === 0) {
+            // this means that the video was rotated 90 or 270, which is not a problem for the encoder but ffprobe returns the rotated dimensions.
+            $width = $this->get("height");
+            $height = $this->get("width");
+        } else {
+            $width = $this->get("width");
+            $height = $this->get("height");
+        }
 
         if (null !== $ratio = $this->extractRatio($this, 'sample_aspect_ratio')) {
             $sampleRatio = $ratio;


### PR DESCRIPTION

| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

When a video is rotated with a `displaymatrix`, notably when recorded on an iPhone, `ffprobe` returns the dimensions with the rotation applied. So e.g. a **portrait** video of **720x1280** is reported to have a **width of 1280 and height 720**.

This gives problems with the `ResizeFilter`, because it will provide a wrong scaling.

This change checks whether there is a `rotation` set in the `side_data_list` and if it is plus or minus 90 or 270, it returns the dimensions _flipped_, so e.g. width = 720 and height = 1280.

There is probably a more robust way to check the rotation, but I don't know which way...

#### Why?

Resizing with `ResizeFilter` distorts the video.

#### To Do

- [ ] Create tests
